### PR TITLE
Fixed an error for rbs-inline annotation in Style/RbsInline/ParametersSeparator

### DIFF
--- a/lib/rubocop/cop/style/rbs_inline/parameters_separator.rb
+++ b/lib/rubocop/cop/style/rbs_inline/parameters_separator.rb
@@ -11,6 +11,9 @@ module RuboCop
         #   # bad
         #   # @rbs param String
         #
+        #   # bad
+        #   # @rbs :param String
+        #
         #   # good
         #   # @rbs param: String
         #
@@ -43,7 +46,7 @@ module RuboCop
             return true if matched.nil?
             return true if RBS_INLINE_KEYWORDS.include?(matched)
             return true if RBS_INLINE_REGEXP_KEYWORDS.any? { |regexp| matched =~ regexp }
-            return true if matched.include?(':')
+            return true if matched.end_with?(':')
 
             false
           end

--- a/lib/rubocop/cop/style/rbs_inline/parameters_separator.rb
+++ b/lib/rubocop/cop/style/rbs_inline/parameters_separator.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Style
       module RbsInline
-        # IRB::Inline expects annotations comments for parameters are separeted with `:`.
+        # IRB::Inline expects annotations comments for parameters are separeted with `:`or allows annotation comments.
         # This cop checks for comments that do not match the expected pattern.
         #
         # @example
@@ -14,6 +14,8 @@ module RuboCop
         #   # good
         #   # @rbs param: String
         #
+        #   # good
+        #   # @rbs %a{pure}
         class ParametersSeparator < Base
           include RangeHelp
 
@@ -21,18 +23,30 @@ module RuboCop
 
           # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
           RBS_INLINE_KEYWORDS = %w[inherits override use module-self generic skip module class].freeze #: Array[String]
+          RBS_INLINE_REGEXP_KEYWORDS = [/%a{(\w|-)+}/, /%a\((\w|-)+\)/, /%a\[(\w|-)+\]/].freeze #: Array[Regexp]
 
           def on_new_investigation #: void
             processed_source.comments.each do |comment|
               matched = comment.text.match(/\A#\s+@rbs\s+(\S+)/)
-              next unless matched
-              next if RBS_INLINE_KEYWORDS.include?(matched[1] || '')
 
-              add_offense(invalid_location_for(comment)) unless matched[1]&.include?(':')
+              next unless matched
+              next if valid_rbs_inline_comment?(matched[1])
+
+              add_offense(invalid_location_for(comment))
             end
           end
 
           private
+
+          # @rbs matched: String?
+          def valid_rbs_inline_comment?(matched) #: bool
+            return true if matched.nil?
+            return true if RBS_INLINE_KEYWORDS.include?(matched)
+            return true if RBS_INLINE_REGEXP_KEYWORDS.any? { |regexp| matched =~ regexp }
+            return true if matched.include?(':')
+
+            false
+          end
 
           # @rbs comment: Parser::Source::Comment
           def invalid_location_for(comment) #: Parser::Source::Range

--- a/sig/rubocop/cop/style/rbs_inline/parameters_separator.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/parameters_separator.rbs
@@ -11,6 +11,9 @@ module RuboCop
         #   # bad
         #   # @rbs param String
         #
+        #   # bad
+        #   # @rbs :param String
+        #
         #   # good
         #   # @rbs param: String
         #

--- a/sig/rubocop/cop/style/rbs_inline/parameters_separator.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/parameters_separator.rbs
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Style
       module RbsInline
-        # IRB::Inline expects annotations comments for parameters are separeted with `:`.
+        # IRB::Inline expects annotations comments for parameters are separeted with `:`or allows annotation comments.
         # This cop checks for comments that do not match the expected pattern.
         #
         # @example
@@ -13,6 +13,9 @@ module RuboCop
         #
         #   # good
         #   # @rbs param: String
+        #
+        #   # good
+        #   # @rbs %a{pure}
         class ParametersSeparator < Base
           include RangeHelp
 
@@ -21,9 +24,14 @@ module RuboCop
           # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
           RBS_INLINE_KEYWORDS: Array[String]
 
+          RBS_INLINE_REGEXP_KEYWORDS: Array[Regexp]
+
           def on_new_investigation: () -> void
 
           private
+
+          # @rbs matched: String?
+          def valid_rbs_inline_comment?: (String? matched) -> bool
 
           # @rbs comment: Parser::Source::Comment
           def invalid_location_for: (Parser::Source::Comment comment) -> Parser::Source::Range

--- a/spec/rubocop/cop/style/rbs_inline/parameters_separator_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/parameters_separator_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::ParametersSeparator, :config do
       # @rbs **: String
       # @rbs return: String
 
+      # @rbs %a{pure}
+      # @rbs %a[pure]
+      # @rbs %a(pure)
+      # @rbs %a{pure} %a{implicitly-returns-nil}
+      # @rbs %a{implicitly-returns-nil}
+      # @rbs %a(implicitly-returns-nil)
+      # @rbs %a[implicitly-returns-nil]
+
       # @rbs inherits String
       # @rbs override
       # @rbs use String

--- a/spec/rubocop/cop/style/rbs_inline/parameters_separator_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/parameters_separator_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::ParametersSeparator, :config do
              ^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
       # @rbs return String
              ^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
+      # @rbs :return String
+             ^^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
+      # @rbs :param String
+             ^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
     RUBY
   end
 


### PR DESCRIPTION
I have found rubocop-rbs_inline and am considering adapting it to my own project.

* Style/RbsInline/ParametersSeparator also detects errors for annotations (e.g. %a{pure}) in rbs-inline, which I have fixed.
  * c7ec80030d6f3ec043b2ebd1f92c2823bb24eca6


* Also, the ending colon check in rbs-inline was fixed.
because I thought String#end_with? was appropriate instead of String#include?
  * 0ff383cdbb13bff61bb0ea5e21f70f0c72eee0f6