### PR TITLE
Supports forward parameter in Style/RbsInline/UnmatchedAnnotations

### DIFF
--- a/lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb
+++ b/lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb
@@ -76,7 +76,7 @@ module RuboCop
 
           # @rbs node: Parser::AST::Node
           def arguments_for(node) #: Array[String] # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-            args_for(node).children.flat_map do |argument|
+            args_for(node).children.flat_map do |argument| # rubocop:disable Metrics/BlockLength
               name = argument.children[0]&.to_s
               case argument.type
               when :arg, :optarg, :kwarg, :kwoptarg
@@ -99,6 +99,8 @@ module RuboCop
                 else
                   ['&', '&block']
                 end
+              when :forward_arg
+                ['...']
               else
                 raise
               end

--- a/spec/rubocop/cop/style/rbs_inline/unmatched_annotations_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/unmatched_annotations_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::UnmatchedAnnotations, :config do
           # @rbs &: String
           # @rbs return: String
           def method(arg1, arg2 = nil, *args, kwarg1:, kwarg2: nil, **kwargs, &block); end
+
+          # @rbs skip
+          def method(...); end
         RUBY
       end
     end


### PR DESCRIPTION
* Fixes an error in the method definition of the forward parameter Style/RbsInline/UnmatchedAnnotations.

## before 
```
RuboCop::Cop::Style::RbsInline::UnmatchedAnnotations
  when an annotation comment found above the instance method definition
    when the comment annotates to unknown argument
      registers an offense
    when the comment annotates to known arguments
      does not register an offense (FAILED - 1)
    when the comment annotates to the instance variable
      registers an offense
  when an annotation comment found above the singleton method definition
    when the comment annotates to unknown argument
      registers an offense
    when the comment annotates to known arguments
      does not register an offense
  when an independent annotation comment found
    registers an offense

Failures:

  1) RuboCop::Cop::Style::RbsInline::UnmatchedAnnotations when an annotation comment found above the instance method definition when the comment annotates to known arguments does not register an offense
     Failure/Error: raise
     RuntimeError:
     # ./lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb:105:in `block in arguments_for'
     # ./lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb:80:in `each'
     # ./lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb:80:in `flat_map'
     # ./lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb:80:in `arguments_for'
     # ./lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb:62:in `process'
     # ./lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb:35:in `on_def'
     # ./spec/rubocop/cop/style/rbs_inline/unmatched_annotations_spec.rb:23:in `block (4 levels) in <top (required)>'

Finished in 0.13674 seconds (files took 0.62966 seconds to load)
6 examples, 1 failure

Failed examples:

rspec ./spec/rubocop/cop/style/rbs_inline/unmatched_annotations_spec.rb:22 # RuboCop::Cop::Style::RbsInline::UnmatchedAnnotations when an annotation comment found above the instance method definition when the comment annotates to known arguments does not register an offense
```

## after 

```
RuboCop::Cop::Style::RbsInline::UnmatchedAnnotations
  when an annotation comment found above the instance method definition
    when the comment annotates to unknown argument
      registers an offense
    when the comment annotates to known arguments
      does not register an offense
    when the comment annotates to the instance variable
      registers an offense
  when an annotation comment found above the singleton method definition
    when the comment annotates to unknown argument
      registers an offense
    when the comment annotates to known arguments
      does not register an offense
  when an independent annotation comment found
    registers an offense

Finished in 0.16061 seconds (files took 0.63242 seconds to load)
6 examples, 0 failures'

```