### PR TITLE
Use RuboCop RSpec 3.5 and RuboCop Rake 0.7 for development

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rake
   - rubocop-rspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ gem 'rake', '~> 13.0'
 
 gem 'rspec'
 gem 'rubocop', '~> 1.74'
-gem 'rubocop-rake'
-gem 'rubocop-rspec'
+gem 'rubocop-rake', '~> 0.7'
+gem 'rubocop-rspec', '~> 3.5'
 gem 'steep', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,9 +129,9 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec
   rubocop (~> 1.74)
-  rubocop-rake
+  rubocop-rake (~> 0.7)
   rubocop-rbs_inline!
-  rubocop-rspec
+  rubocop-rspec (~> 3.5)
   steep
 
 BUNDLED WITH


### PR DESCRIPTION
This PR uses RuboCop RSpec 3.5 and RuboCop Rake 0.7 for development and suppresses the following warning:

```
$ bundle exec rubocop
rubocop-rake extension supports plugin, specify `plugins: rubocop-rake` instead of `require: rubocop-rake` in /ydah/rubocop-rbs_inline/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /ydah/rubocop-rbs_inline/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```