### PR TITLE
Fix false positives in RBS method type signature handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.5.5 (2026-05-19)
+
+### Bug Fixes
+
+- **Style/RbsInline/ParametersSeparator**: No longer reports false positives for `# @rbs` method type signature annotations such as `# @rbs (Type) -> ReturnType` or `# @rbs [T] (T) -> T`.
+- **Style/RbsInline/MissingTypeAnnotation**: Recognizes `# @rbs` method type signature annotations (e.g. `# @rbs (Type) -> ReturnType`) as satisfying the `method_type_signature` and `method_type_signature_or_return_annotation` styles.
+
 ## 1.5.4 (2026-03-30)
 
 ### Internal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-rbs_inline (1.5.4)
+    rubocop-rbs_inline (1.5.5)
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)

--- a/lib/rubocop/rbs_inline/version.rb
+++ b/lib/rubocop/rbs_inline/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module RbsInline
-    VERSION = '1.5.4'
+    VERSION = '1.5.5'
   end
 end


### PR DESCRIPTION
## Summary

This release fixes false positives in two RBS::Inline cops when handling `# @rbs` method type signature annotations. The cops now correctly recognize method type signatures like `# @rbs (Type) -> ReturnType` and `# @rbs [T] (T) -> T`.

## Key Changes

- **Style/RbsInline/ParametersSeparator**: Fixed to no longer report false positives for `# @rbs` method type signature annotations. These annotations use `->` syntax rather than `:` separators and should not be flagged.

- **Style/RbsInline/MissingTypeAnnotation**: Enhanced to recognize `# @rbs` method type signature annotations as satisfying both `method_type_signature` and `method_type_signature_or_return_annotation` configuration styles.

- **Version**: Bumped to 1.5.5

## Implementation Details

The fixes ensure that method type signatures in the form `# @rbs (ParameterType) -> ReturnType` and generic signatures like `# @rbs [T] (T) -> T` are properly handled by the annotation parsing logic, preventing incorrect offense reporting while still validating other annotation styles as intended.

https://claude.ai/code/session_01Qv52ikSETrSjsymLygiS6v