### PR TITLE
ci: disable bundler cache in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: 3.3
-          bundler-cache: true
+          # Skip bundler cache to avoid the cache-poisoning attack at release time:
+          # a poisoned cache written from a PR could otherwise be reused here
+          # and end up shipped to RubyGems.
+          # See https://docs.zizmor.sh/audits/#cache-poisoning
+          bundler-cache: false
+      - name: Install dependencies
+        run: bundle install
       - name: Publish to RubyGems
         uses: rubygems/release-gem@f0d7faff26625599a847d40d9fa28ace24c2aacc # v1


### PR DESCRIPTION
## Summary

Disable `bundler-cache` in `release.yml` and run `bundle install` explicitly as a separate step instead.

This addresses the `cache-poisoning` finding from `zizmor`. GitHub Actions caches are shared across branches of the same repository: a malicious PR can run a job that writes to the cache under a key derived from `Gemfile.lock`, and a later release workflow that reads from the same key would pull that poisoned cache. For ordinary CI workflows this is a low-impact risk (the worst case is a failing test), but for a release workflow the output is published to RubyGems and distributed to users — so the blast radius of a poisoned cache is much larger there.

The fix is to skip the cache in `release.yml` and let `bundle install` always resolve dependencies fresh from the network. CI workflows (`main.yml`) keep `bundler-cache: true` because the speed benefit there outweighs the (smaller) risk. An inline comment is left next to `bundler-cache: false` so a future reader does not flip it back to `true` for the speed win without realising the security trade-off.

References:
- https://docs.zizmor.sh/audits/#cache-poisoning
- https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/

## Test plan

- [x] `actionlint` passes
- [ ] Next release tag push will exercise the new bundle-install-without-cache path