### PR TITLE
Align rake ci with the skeleton: split rbs:check into steep + rbs:validate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Install RBS Collection
-      run: bundle exec rbs collection install --frozen
     - name: Run the default task
       run: bundle exec rake

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ bundle exec rake rubocop:autocorrect       # safe autocorrect
 bundle exec rake rubocop:autocorrect_all   # all autocorrect
 
 # Type check
-bundle exec rake rbs:check                 # runs steep check
+bundle exec rake steep                     # runs steep check
+bundle exec rake rbs:validate              # validates RBS signatures
 
 # Default rake task (runs specs, rubocop, and type check)
 bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,9 @@ require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
-task default: %i[spec rubocop rbs:check]
+task default: :ci
+
+task ci: %i[rubocop spec steep rbs:validate]
 
 require 'rspec/core/rake_task'
 
@@ -33,9 +35,23 @@ task :new_cop, [:cop] do |_task, args|
 end
 
 namespace :rbs do
-  desc 'Do type check using Steep'
-  task :check do
-    sh 'rbs', '-Isig', 'validate'
-    sh 'bundle', 'exec', 'steep', 'check'
+  desc 'Install RBS signatures'
+  task :install do
+    sh 'bundle', 'exec', 'rbs', 'collection', 'install', '--frozen'
   end
+
+  desc 'Generate RBS files'
+  task :generate do
+    sh 'rbs-inline', '--opt-out', '--output=sig', 'lib'
+  end
+
+  desc 'Validate RBS files'
+  task validate: 'rbs:install' do
+    sh 'rbs', '-Isig', 'validate'
+  end
+end
+
+desc 'Run Steep type checker'
+task steep: 'rbs:install' do
+  sh 'bundle', 'exec', 'steep', 'check'
 end


### PR DESCRIPTION
## Summary

Brings the Rakefile in line with the `init-ruby-project` skeleton. The combined `rbs:check` task is split into separate `steep` and `rbs:validate` tasks, and a `ci` task (`rubocop spec steep rbs:validate`) becomes the default. The collection install moves from the workflow into an `rbs:install` task.

## Changes

- `Rakefile`
  - `task default: :ci`, `task ci: %i[rubocop spec steep rbs:validate]`
  - add `rbs:install` (`rbs collection install --frozen`)
  - split `rbs:check` into `steep` (`steep check`) and `rbs:validate` (`rbs -Isig validate`), both depending on `rbs:install`
  - keep the `new_cop` task
- `.github/workflows/main.yml`
  - drop the separate `Install RBS Collection` step (now handled by `rbs:install`); the job just runs `bundle exec rake`
- `CLAUDE.md`
  - reference `rake steep` / `rake rbs:validate` instead of `rake rbs:check`

## Notes

- Rake dedupes prerequisites, so the collection is installed exactly once per `rake ci`.
- Preserves this repo's single-quote string style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)