### PR TITLE
Release version 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.6.0 (2026-07-05)
+
+### Changes
+
+- All cops now exclude `spec/**/*` and `test/**/*` by default. Override with `Exclude: []` per cop to lint annotations in test code.
+
+### Bug Fixes
+
+- **Style/RbsInline/UntypedInstanceVariable**: No longer reports a false positive for class instance variables (assigned inside `class << self` or `def self.foo`) that have a `# @rbs self.@name: Type` annotation.
+
 ## 1.5.5 (2026-05-19)
 
 ### Bug Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-rbs_inline (1.5.5)
+    rubocop-rbs_inline (1.6.0)
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)

--- a/lib/rubocop/rbs_inline/version.rb
+++ b/lib/rubocop/rbs_inline/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module RbsInline
-    VERSION = '1.5.5'
+    VERSION = '1.6.0'
   end
 end


### PR DESCRIPTION
## Summary

This release introduces a new default behavior for all cops to exclude test files, and fixes a false positive in the `Style/RbsInline/UntypedInstanceVariable` cop.

## Key Changes

- **Default test file exclusion**: All cops now exclude `spec/**/*` and `test/**/*` by default. Users can override this per cop by setting `Exclude: []` if they want to lint annotations in test code.

- **Bug fix**: Fixed `Style/RbsInline/UntypedInstanceVariable` to no longer report false positives for class instance variables (those assigned inside `class << self` or `def self.foo`) that have a `# @rbs self.@name: Type` annotation.

- **Version bump**: Updated version from 1.5.5 to 1.6.0

## Implementation Details

The changes align with common RuboCop practices where test files are typically excluded from linting by default, while still allowing users to customize this behavior on a per-cop basis.

https://claude.ai/code/session_01NJTwk4rBnHRWUyiaVya2Ma