### PR TITLE
Introduce rubocop-numbered-params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 plugins:
+  - rubocop-numbered-params
   - rubocop-rake
   - rubocop-rspec
   - rubocop-rbs_inline

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rake', '~> 13.4'
 
 gem 'rspec'
 gem 'rubocop', '~> 1.88'
+gem 'rubocop-numbered-params'
 gem 'rubocop-rake', '~> 0.7'
 gem 'rubocop-rspec', '~> 3.10'
 gem 'steep', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-numbered-params (1.0.0)
+      lint_roller (~> 1.0)
+      rubocop (>= 1.72.1)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
@@ -111,10 +114,11 @@ DEPENDENCIES
   rake (~> 13.4)
   rspec
   rubocop (~> 1.88)
+  rubocop-numbered-params
   rubocop-rake (~> 0.7)
   rubocop-rbs_inline!
   rubocop-rspec (~> 3.10)
   steep
 
 BUNDLED WITH
-   4.0.15
+  4.0.15

--- a/lib/rubocop/cop/style/rbs_inline/comment_parser.rb
+++ b/lib/rubocop/cop/style/rbs_inline/comment_parser.rb
@@ -49,7 +49,7 @@ module RuboCop
 
               # Exclude trailing inline comments (e.g., `def method = value #: Type`)
               # by verifying all comment lines contain only whitespace before '#'
-              r.comments.all? { |c| processed_source.buffer.source_line(c.location.start_line).match?(/\A\s*#/) }
+              r.comments.all? { processed_source.buffer.source_line(_1.location.start_line).match?(/\A\s*#/) }
             end
           end
 
@@ -60,8 +60,8 @@ module RuboCop
             return unless leading_annotation
 
             annotation_lines = leading_annotation.comments
-                                                 .select { |c| c.location.slice.start_with?('#:') }
-                                                 .map { |c| c.location.start_line }
+                                                 .select { _1.location.slice.start_with?('#:') }
+                                                 .map { _1.location.start_line }
             return if annotation_lines.empty?
 
             comments = processed_source.comments.select do |c|

--- a/lib/rubocop/cop/style/rbs_inline/method_comment_spacing.rb
+++ b/lib/rubocop/cop/style/rbs_inline/method_comment_spacing.rb
@@ -166,7 +166,7 @@ module RuboCop
           # @rbs comment: RBS::Inline::AnnotationParser::ParsingResult
           def skip_only_annotation?(comment) #: bool
             annotations = [] #: Array[RBS::Inline::AST::Annotations::t]
-            comment.each_annotation { |a| annotations << a }
+            comment.each_annotation { annotations << _1 }
             annotations.any? && annotations.all?(RBS::Inline::AST::Annotations::Skip)
           end
 

--- a/lib/rubocop/cop/style/rbs_inline/missing_data_class_annotation.rb
+++ b/lib/rubocop/cop/style/rbs_inline/missing_data_class_annotation.rb
@@ -123,7 +123,7 @@ module RuboCop
             data_attributes(node).each do |arg|
               next if inline_type_annotation?(arg.location.line)
 
-              add_offense(arg) { |corrector| correct_multiline(corrector, node, arg) }
+              add_offense(arg) { correct_multiline(_1, node, arg) }
             end
           end
 

--- a/lib/rubocop/cop/style/rbs_inline/missing_type_annotation.rb
+++ b/lib/rubocop/cop/style/rbs_inline/missing_type_annotation.rb
@@ -392,7 +392,7 @@ module RuboCop
             annotation = find_leading_annotation(line)
             return false unless annotation
 
-            annotation.comments.any? { |c| c.location.slice.match?(/\A#\s+@rbs\s+(skip|override)\b/) }
+            annotation.comments.any? { _1.location.slice.match?(/\A#\s+@rbs\s+(skip|override)\b/) }
           end
 
           # @rbs line: Integer

--- a/lib/rubocop/cop/style/rbs_inline/parameters_separator.rb
+++ b/lib/rubocop/cop/style/rbs_inline/parameters_separator.rb
@@ -49,7 +49,7 @@ module RuboCop
           def valid_rbs_inline_comment?(matched) #: bool
             return true if matched.nil?
             return true if RBS_INLINE_KEYWORDS.include?(matched)
-            return true if RBS_INLINE_REGEXP_KEYWORDS.any? { |regexp| matched =~ regexp }
+            return true if RBS_INLINE_REGEXP_KEYWORDS.any? { matched =~ _1 }
             return true if matched.end_with?(':')
             # method type signature, e.g. `# @rbs (Integer) -> String` or `# @rbs [T] (T) -> T`
             return true if matched.start_with?('(', '[')

--- a/lib/rubocop/cop/style/rbs_inline/untyped_instance_variable.rb
+++ b/lib/rubocop/cop/style/rbs_inline/untyped_instance_variable.rb
@@ -90,8 +90,8 @@ module RuboCop
           end
 
           def on_investigation_end #: void
-            ivar_type_annotations.each_value { |name| current_scope[:typed_ivars] << name }
-            civar_type_annotations.each_value { |name| current_scope[:typed_class_ivars] << name }
+            ivar_type_annotations.each_value { current_scope[:typed_ivars] << _1 }
+            civar_type_annotations.each_value { current_scope[:typed_class_ivars] << _1 }
             report_offenses
             pop_scope
           end
@@ -196,7 +196,7 @@ module RuboCop
           def collect_ivar_type_annotations #: [Hash[Integer, Symbol], Hash[Integer, Symbol]]
             ivar = {} #: Hash[Integer, Symbol]
             civar = {} #: Hash[Integer, Symbol]
-            parsed_comments.flat_map { |r| r.each_annotation.to_a }.each do |ann|
+            parsed_comments.flat_map { _1.each_annotation.to_a }.each do |ann|
               next unless ann.is_a?(RBS::Inline::AST::Annotations::IvarType)
 
               if ann.class_instance

--- a/lib/rubocop/cop/style/rbs_inline/variable_comment_spacing.rb
+++ b/lib/rubocop/cop/style/rbs_inline/variable_comment_spacing.rb
@@ -54,7 +54,7 @@ module RuboCop
           def check_variable_comment(comment) #: void
             return unless comment.text.match?(VARIABLE_COMMENT_PATTERN)
 
-            last_comment_line = find_last_consecutive_comment(comment) { |c| c.text.match?(VARIABLE_COMMENT_PATTERN) }
+            last_comment_line = find_last_consecutive_comment(comment) { _1.text.match?(VARIABLE_COMMENT_PATTERN) }
             next_line_number = last_comment_line.loc.line + 1
 
             return if blank_line?(next_line_number)

--- a/rubocop-rbs_inline.gemspec
+++ b/rubocop-rbs_inline.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = 'exe'
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'lint_roller', '~> 1.1'


### PR DESCRIPTION
Add the `rubocop-numbered-params` plugin to enforce a consistent style for numbered block parameters, matching the setup already used in other repositories.

- Add `rubocop-numbered-params` to the Gemfile and Gemfile.lock
- Register the plugin in `.rubocop.yml`
- Autocorrect existing offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)