### PR TITLE
Fix department-level Exclude config to honor user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Restored honor for department-level `Style/RbsInline: Exclude:` configuration in user's `.rubocop.yml`. Since 1.6.0, per-cop `Exclude` defaults masked the user setting; the default `spec/**/*` and `test/**/*` exclusion is now declared at the department level with `inherit_mode: merge`, so user-supplied paths are added instead of replaced.
+
 ## 1.6.0 (2026-07-05)
 
 ### Changes

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,66 +1,50 @@
+Style/RbsInline:
+  inherit_mode:
+    merge:
+      - Exclude
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+
 Style/RbsInline/DataClassCommentAlignment:
   Description: "Checks that `#:` inline type annotations in `Data.define` blocks are aligned."
   Enabled: true
   VersionAdded: '1.5.0'
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/DataDefineWithBlock:
   Description: "Checks for `Data.define` calls with a block, which RBS::Inline does not parse."
   Enabled: true
   VersionAdded: '1.5.0'
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/EmbeddedRbsSpacing:
   Description: 'Checks that `@rbs!` comments (embedded RBS) are followed by a blank line.'
   Enabled: true
   VersionAdded: '1.5.0'
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/InvalidComment:
   Description: "Checks the rbs-inline annotation comment is valid."
   Enabled: true
   VersionAdded: "1.0.0"
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/InvalidTypes:
   Description: "Checks the rbs-inline annotation comment uses valid types."
   Enabled: true
   VersionAdded: "1.0.0"
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/KeywordSeparator:
   Description: "Checks the rbs-inline annotation comment does not use a separator after the keywords."
   Enabled: true
   VersionAdded: "1.0.0"
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/MethodCommentSpacing:
   Description: 'Checks that method-related `@rbs` annotations are placed immediately before method definitions.'
   Enabled: true
   VersionAdded: '1.5.0'
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/MissingDataClassAnnotation:
   Description: "Checks that `Data.define` attributes have inline type annotations."
   Enabled: true
   VersionAdded: '1.5.0'
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/MissingTypeAnnotation:
   Description: "Checks that method definitions and attr_* declarations have RBS inline type annotations."
@@ -73,34 +57,22 @@ Style/RbsInline/MissingTypeAnnotation:
     - method_type_signature
     - method_type_signature_or_return_annotation
   Visibility: all
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/ParametersSeparator:
   Description: "Checks the rbs-inline annotation comment uses a separator to parameters"
   Enabled: true
   VersionAdded: "1.0.0"
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/RedundantAnnotationWithSkip:
   Description: "Checks for redundant type annotations when `@rbs skip` or `@rbs override` is present."
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '1.5.0'
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/RedundantInstanceVariableAnnotation:
   Description: "Checks for redundant `@rbs` instance variable type annotation when `attr_*` with an inline type annotation is already defined."
   Enabled: true
   VersionAdded: '1.5.0'
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/RedundantTypeAnnotation:
   Description: "Checks for redundant type annotations when multiple type specifications exist for the same method definition."
@@ -112,9 +84,6 @@ Style/RbsInline/RedundantTypeAnnotation:
     - method_type_signature
     - doc_style
     - doc_style_and_return_annotation
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/RequireRbsInlineComment:
   Description: "Checks the presence or absence of `# rbs_inline: enabled` magic comment."
@@ -124,30 +93,18 @@ Style/RbsInline/RequireRbsInlineComment:
   SupportedStyles:
     - always
     - never
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/UnmatchedAnnotations:
   Description: "Checks the rbs-inline annotation comment is surely matched."
   Enabled: true
   VersionAdded: "1.0.0"
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/UntypedInstanceVariable:
   Description: "Checks that instance variables in classes/modules have RBS type annotations."
   Enabled: true
   VersionAdded: '1.5.0'
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
 
 Style/RbsInline/VariableCommentSpacing:
   Description: 'Checks that `@rbs` variable comments are followed by a blank line.'
   Enabled: true
   VersionAdded: '1.5.0'
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'


### PR DESCRIPTION
## Summary

Restores proper handling of user-supplied `Style/RbsInline: Exclude:` configuration in `.rubocop.yml` files. Since version 1.6.0, per-cop `Exclude` defaults were masking user settings instead of merging with them.

## Changes

- **config/default.yml**: Moved the `spec/**/*` and `test/**/*` exclusion patterns from individual cop configurations to a new department-level `Style/RbsInline` section with `inherit_mode: merge`
  - This ensures user-supplied exclusion paths are added to (rather than replaced by) the default exclusions
  - Removed duplicate `Exclude` entries from all 16 child cops under `Style/RbsInline`

- **CHANGELOG.md**: Added entry documenting the bug fix in the Unreleased section

## Implementation Details

The fix leverages RuboCop's `inherit_mode: merge` feature at the department level. By declaring the default exclusions at the parent `Style/RbsInline` level rather than repeating them in each individual cop, user configurations now properly merge with defaults instead of being overridden. This is a configuration-only change with no impact to cop logic or behavior.

https://claude.ai/code/session_01N1jgtC4RbeyQL4pCrMNA2a