### PR TITLE
Release v1.6.1: Fix Style/RbsInline Exclude configuration regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## Unreleased
+## 1.6.1 (2026-07-10)
 
 ### Bug Fixes
 
-- Restored honor for department-level `Style/RbsInline: Exclude:` configuration in user's `.rubocop.yml`. Since 1.6.0, per-cop `Exclude` defaults masked the user setting; the default `spec/**/*` and `test/**/*` exclusion is now declared at the department level with `inherit_mode: merge`, so user-supplied paths are added instead of replaced.
+- Fixed user's `Style/RbsInline: Exclude:` configuration being ignored (regression from 1.6.0).
 
 ## 1.6.0 (2026-07-05)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-rbs_inline (1.6.0)
+    rubocop-rbs_inline (1.6.1)
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)

--- a/lib/rubocop/rbs_inline/version.rb
+++ b/lib/rubocop/rbs_inline/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module RbsInline
-    VERSION = "1.6.0"
+    VERSION = "1.6.1"
   end
 end


### PR DESCRIPTION
## Summary

This release fixes a regression introduced in v1.6.0 where user-supplied `Style/RbsInline: Exclude:` configuration in `.rubocop.yml` was being ignored.

## Changes

- **Version bump**: Updated version from 1.6.0 to 1.6.1
- **CHANGELOG update**: Documented the bug fix with a concise description of the issue

## Details

In v1.6.0, per-cop `Exclude` defaults were masking user settings. This has been resolved by declaring the default `spec/**/*` and `test/**/*` exclusion at the department level with `inherit_mode: merge`, allowing user-supplied paths to be added instead of replaced.

https://claude.ai/code/session_01LSBNr6d7ezMgmJ2YKSAtc8