### PR TITLE
Replace any? with intersect? for set membership check

### DIFF
--- a/lib/rubocop/cop/style/rbs_inline/missing_type_annotation.rb
+++ b/lib/rubocop/cop/style/rbs_inline/missing_type_annotation.rb
@@ -320,7 +320,7 @@ module RuboCop
 
               candidates = param_candidate_names(argument, name)
               next unless candidates
-              next if candidates.any? { annotated_names.include?(_1) }
+              next if candidates.intersect?(annotated_names)
 
               add_offense(argument, message: format(DOC_STYLE_PARAM_MESSAGE, name: param_display_name(argument)))
             end


### PR DESCRIPTION
## Summary

Simplify and optimize a set membership check in the `MissingTypeAnnotation` cop by replacing an `any?` iteration with the more idiomatic `intersect?` method.

## Changes

- Replace `candidates.any? { annotated_names.include?(_1) }` with `candidates.intersect?(annotated_names)` in the `check_method_parameters_in_doc_style` method

## Details

The original code checked if any candidate parameter name was already annotated by iterating through candidates and checking membership in the annotated_names set. The `intersect?` method is more semantically clear for this use case—it directly expresses the intent of checking whether two collections have any common elements—and is likely more performant for larger collections.

https://claude.ai/code/session_01S6Tf68JMdasFFnosJwCgx2