### PR TITLE
Release version 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.7.0 (2026-07-20)
 
 ### New Features
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-rbs_inline (1.6.1)
+    rubocop-rbs_inline (1.7.0)
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)

--- a/lib/rubocop/rbs_inline/version.rb
+++ b/lib/rubocop/rbs_inline/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module RbsInline
-    VERSION = "1.6.1"
+    VERSION = "1.7.0"
   end
 end


### PR DESCRIPTION
## Summary
This release bumps the gem version to 1.7.0 and updates the changelog with the release date.

## Changes
- Updated `VERSION` constant from `1.6.1` to `1.7.0` in `lib/rubocop/rbs_inline/version.rb`
- Updated CHANGELOG.md to mark version 1.7.0 as released on 2026-07-20

## Notes
This is a version bump release. The actual feature changes for 1.7.0 should have been documented in the "New Features" section of CHANGELOG.md in prior commits.

https://claude.ai/code/session_015Pa2yAY9Sa1CeyQcAjcKUB