### PR TITLE
Allow RemoteTrigger permission by default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "permissions": {
+    "allow": ["RemoteTrigger"]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
Auto-approve Claude Code on the web self check-ins ("send later") without prompting every time by adding `RemoteTrigger` to `permissions.allow` in `.claude/settings.json`.

This propagates the recent change from the `setup-dev-workflow-hooks` skill skeleton.