### PR TITLE
Refactor spec files to use context/it structure

### DIFF
--- a/spec/rubocop/cop/style/rbs_inline/data_class_comment_alignment_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/data_class_comment_alignment_spec.rb
@@ -3,142 +3,164 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::DataClassCommentAlignment, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense and corrects an annotation that is too close" do
-    expect_offense(<<~RUBY)
-      MethodEntry = Data.define(
-        :name, #: Symbol
-               ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
-        :node,       #: Parser::AST::Node
-        :visibility  #: Symbol
-      )
-    RUBY
+  context "when an annotation is too close" do
+    it "registers an offense and corrects it" do
+      expect_offense(<<~RUBY)
+        MethodEntry = Data.define(
+          :name, #: Symbol
+                 ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
+          :node,       #: Parser::AST::Node
+          :visibility  #: Symbol
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: Symbol
-        :node,       #: Parser::AST::Node
-        :visibility  #: Symbol
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: Symbol
+          :node,       #: Parser::AST::Node
+          :visibility  #: Symbol
+        )
+      RUBY
+    end
   end
 
-  it "registers an offense and corrects an annotation that is too far" do
-    expect_offense(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,           #: Symbol
-                         ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
-        :node,       #: Parser::AST::Node
-        :visibility  #: Symbol
-      )
-    RUBY
+  context "when an annotation is too far" do
+    it "registers an offense and corrects it" do
+      expect_offense(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,           #: Symbol
+                           ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
+          :node,       #: Parser::AST::Node
+          :visibility  #: Symbol
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: Symbol
-        :node,       #: Parser::AST::Node
-        :visibility  #: Symbol
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: Symbol
+          :node,       #: Parser::AST::Node
+          :visibility  #: Symbol
+        )
+      RUBY
+    end
   end
 
-  it "registers offenses and corrects multiple misaligned annotations" do
-    expect_offense(<<~RUBY)
-      MethodEntry = Data.define(
-        :name, #: Symbol
-               ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
-        :node, #: Parser::AST::Node
-               ^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
-        :visibility #: Symbol
-                    ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
-      )
-    RUBY
+  context "when multiple annotations are misaligned" do
+    it "registers offenses and corrects them" do
+      expect_offense(<<~RUBY)
+        MethodEntry = Data.define(
+          :name, #: Symbol
+                 ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
+          :node, #: Parser::AST::Node
+                 ^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
+          :visibility #: Symbol
+                      ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: Symbol
-        :node,       #: Parser::AST::Node
-        :visibility  #: Symbol
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: Symbol
+          :node,       #: Parser::AST::Node
+          :visibility  #: Symbol
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense when all annotations are already aligned" do
-    expect_no_offenses(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: Symbol
-        :node,       #: Parser::AST::Node
-        :visibility  #: Symbol
-      )
-    RUBY
+  context "when all annotations are already aligned" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: Symbol
+          :node,       #: Parser::AST::Node
+          :visibility  #: Symbol
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense when there are no annotations" do
-    expect_no_offenses(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,
-        :node,
-        :visibility
-      )
-    RUBY
+  context "when there are no annotations" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,
+          :node,
+          :visibility
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense when only one attribute has an annotation" do
-    expect_no_offenses(<<~RUBY)
-      AggregatedResult = Data.define(
-        :results,
-        :errors  #: Array[String]
-      )
-    RUBY
+  context "when only one attribute has an annotation" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        AggregatedResult = Data.define(
+          :results,
+          :errors  #: Array[String]
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense when there is only one attribute with an annotation" do
-    expect_no_offenses(<<~RUBY)
-      Foo = Data.define(
-        :bar  #: String
-      )
-    RUBY
+  context "when there is only one attribute with an annotation" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo = Data.define(
+          :bar  #: String
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense for folded Data.define" do
-    expect_no_offenses(<<~RUBY)
-      MethodEntry = Data.define(:name, :node, :visibility)
-    RUBY
+  context "with folded Data.define" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        MethodEntry = Data.define(:name, :node, :visibility)
+      RUBY
+    end
   end
 
-  it "does not register an offense for attributes folded inside parentheses" do
-    expect_no_offenses(<<~RUBY)
-      MethodEntry = Data.define(
-        :name, :node, :visibility
-      )
-    RUBY
+  context "with attributes folded inside parentheses" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        MethodEntry = Data.define(
+          :name, :node, :visibility
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense for other method calls named define" do
-    expect_no_offenses(<<~RUBY)
-      Foo.define(
-        :name, #: Symbol
-        :node, #: Parser::AST::Node
-      )
-    RUBY
+  context "with other method calls named define" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo.define(
+          :name, #: Symbol
+          :node, #: Parser::AST::Node
+        )
+      RUBY
+    end
   end
 
-  it "handles splat arguments correctly" do
-    expect_offense(<<~RUBY)
-      Data.define(
-        :foo, #: Integer
-              ^^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
-        :bar, #: String
-              ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
-        *QUX_QUUX
-      )
-    RUBY
+  context "with splat arguments" do
+    it "handles them correctly" do
+      expect_offense(<<~RUBY)
+        Data.define(
+          :foo, #: Integer
+                ^^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
+          :bar, #: String
+                ^^^^^^^^^ Style/RbsInline/DataClassCommentAlignment: Misaligned inline type annotation for Data attribute.
+          *QUX_QUUX
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Data.define(
-        :foo,      #: Integer
-        :bar,      #: String
-        *QUX_QUUX
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Data.define(
+          :foo,      #: Integer
+          :bar,      #: String
+          *QUX_QUUX
+        )
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/data_define_with_block_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/data_define_with_block_spec.rb
@@ -3,64 +3,78 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::DataDefineWithBlock, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense when Data.define is called with a do...end block" do
-    expect_offense(<<~RUBY)
-      User = Data.define(:name, :role) do
-             ^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
-        def admin?
-          role == :admin
+  context "when Data.define is called with a do...end block" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        User = Data.define(:name, :role) do
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+          def admin?
+            role == :admin
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 
-  it "registers an offense when Data.define is called with a brace block" do
-    expect_offense(<<~RUBY)
-      User = Data.define(:name, :role) { }
-             ^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
-    RUBY
+  context "when Data.define is called with a brace block" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        User = Data.define(:name, :role) { }
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+      RUBY
+    end
   end
 
-  it "registers an offense when Data.define with no args is called with a block" do
-    expect_offense(<<~RUBY)
-      Empty = Data.define do
-              ^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
-        def foo
-          42
+  context "when Data.define with no args is called with a block" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        Empty = Data.define do
+                ^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+          def foo
+            42
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 
-  it "does not register an offense when Data.define is called without a block" do
-    expect_no_offenses(<<~RUBY)
-      User = Data.define(:name, :role)
-    RUBY
+  context "when Data.define is called without a block" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        User = Data.define(:name, :role)
+      RUBY
+    end
   end
 
-  it "does not register an offense when class is reopened separately" do
-    expect_no_offenses(<<~RUBY)
-      User = Data.define(:name, :role)
+  context "when class is reopened separately" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        User = Data.define(:name, :role)
 
-      class User
-        def admin?
-          role == :admin
+        class User
+          def admin?
+            role == :admin
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 
-  it "does not register an offense for other define calls with a block" do
-    expect_no_offenses(<<~RUBY)
-      Foo.define(:name) do
-      end
-    RUBY
+  context "with other define calls with a block" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo.define(:name) do
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for Struct.new with a block" do
-    expect_no_offenses(<<~RUBY)
-      Foo = Struct.new(:name) do
-      end
-    RUBY
+  context "with Struct.new with a block" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo = Struct.new(:name) do
+        end
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/embedded_rbs_spacing_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/embedded_rbs_spacing_spec.rb
@@ -3,195 +3,223 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::EmbeddedRbsSpacing, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense when @rbs! comment is directly followed by code" do
-    expect_offense(<<~RUBY)
-      # @rbs! type foo = Integer
-      def method
-      ^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs! type foo = Integer
-
-      def method
-      end
-    RUBY
-  end
-
-  it "registers an offense when @rbs! block is directly followed by code" do
-    expect_offense(<<~RUBY)
-      # @rbs! type foo = Integer
-      #  type bar = String
-      def method
-      ^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs! type foo = Integer
-      #  type bar = String
-
-      def method
-      end
-    RUBY
-  end
-
-  it "does not register an offense when @rbs! comment is followed by a blank line" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs! type foo = Integer
-
-      def method
-      end
-    RUBY
-  end
-
-  it "does not register an offense when @rbs! block is followed by a blank line" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs! type foo = Integer
-      #  type bar = String
-
-      def method
-      end
-    RUBY
-  end
-
-  it "does not register an offense when @rbs! comment is at the end of file" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs! type foo = Integer
-    RUBY
-  end
-
-  it "does not register an offense when @rbs! comment is at the end of class body" do
-    expect_no_offenses(<<~RUBY)
-      class Foo
-        # @rbs! type foo = Integer
-      end
-    RUBY
-  end
-
-  it "registers an offense when @rbs! with space is directly followed by code" do
-    expect_offense(<<~RUBY)
-      # @rbs! type foo = Integer
-      class Foo
-      ^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs! type foo = Integer
-
-      class Foo
-      end
-    RUBY
-  end
-
-  it "does not register an offense with multiple @rbs! blocks properly spaced" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs! type foo = Integer
-
-      def method1
-      end
-
-      # @rbs! type bar = String
-
-      def method2
-      end
-    RUBY
-  end
-
-  it "registers an offense when multi-line @rbs! block is directly followed by code" do
-    expect_offense(<<~RUBY)
-      # @rbs!
-      #   type foo = Integer
-      #   type bar = String
-      def method
-      ^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs!
-      #   type foo = Integer
-      #   type bar = String
-
-      def method
-      end
-    RUBY
-  end
-
-  it "does not register an offense when multi-line @rbs! block is followed by a blank line" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs!
-      #   type foo = Integer
-      #   type bar = String
-
-      def method
-      end
-    RUBY
-  end
-
-  it "registers an offense when @rbs! block with blank comment line is directly followed by code" do
-    expect_offense(<<~RUBY)
-      # @rbs!
-      #   type foo = Integer
-      #
-      #   type bar = String
-      def method
-      ^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs!
-      #   type foo = Integer
-      #
-      #   type bar = String
-
-      def method
-      end
-    RUBY
-  end
-
-  it "does not register an offense when @rbs! block with blank comment line is followed by a blank line" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs!
-      #   type foo = Integer
-      #
-      #   type bar = String
-
-      def method
-      end
-    RUBY
-  end
-
-  context "with consecutive @rbs! and other @rbs comments" do
-    it "registers an offense when @rbs! is followed by @rbs @ivar without blank line" do
+  context "when @rbs! comment is directly followed by code" do
+    it "registers an offense" do
       expect_offense(<<~RUBY)
         # @rbs! type foo = Integer
-        # @rbs @ivar: Integer
-        ^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
-
-        def bar; end
+        def method
+        ^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
+        end
       RUBY
 
       expect_correction(<<~RUBY)
         # @rbs! type foo = Integer
 
-        # @rbs @ivar: Integer
-
-        def bar; end
+        def method
+        end
       RUBY
     end
+  end
 
-    it "does not register an offense when @rbs! is followed by blank line before @rbs @ivar" do
+  context "when @rbs! block is directly followed by code" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs! type foo = Integer
+        #  type bar = String
+        def method
+        ^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs! type foo = Integer
+        #  type bar = String
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when @rbs! comment is followed by a blank line" do
+    it "does not register an offense" do
       expect_no_offenses(<<~RUBY)
         # @rbs! type foo = Integer
 
-        # @rbs @ivar: Integer
-
-        def bar; end
+        def method
+        end
       RUBY
+    end
+  end
+
+  context "when @rbs! block is followed by a blank line" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs! type foo = Integer
+        #  type bar = String
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when @rbs! comment is at the end of file" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs! type foo = Integer
+      RUBY
+    end
+  end
+
+  context "when @rbs! comment is at the end of class body" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          # @rbs! type foo = Integer
+        end
+      RUBY
+    end
+  end
+
+  context "when @rbs! with space is directly followed by code" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs! type foo = Integer
+        class Foo
+        ^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs! type foo = Integer
+
+        class Foo
+        end
+      RUBY
+    end
+  end
+
+  context "with multiple @rbs! blocks properly spaced" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs! type foo = Integer
+
+        def method1
+        end
+
+        # @rbs! type bar = String
+
+        def method2
+        end
+      RUBY
+    end
+  end
+
+  context "when multi-line @rbs! block is directly followed by code" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs!
+        #   type foo = Integer
+        #   type bar = String
+        def method
+        ^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs!
+        #   type foo = Integer
+        #   type bar = String
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when multi-line @rbs! block is followed by a blank line" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs!
+        #   type foo = Integer
+        #   type bar = String
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when @rbs! block with blank comment line is directly followed by code" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs!
+        #   type foo = Integer
+        #
+        #   type bar = String
+        def method
+        ^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs!
+        #   type foo = Integer
+        #
+        #   type bar = String
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when @rbs! block with blank comment line is followed by a blank line" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs!
+        #   type foo = Integer
+        #
+        #   type bar = String
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "with consecutive @rbs! and other @rbs comments" do
+    context "when @rbs! is followed by @rbs @ivar without blank line" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          # @rbs! type foo = Integer
+          # @rbs @ivar: Integer
+          ^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/EmbeddedRbsSpacing: `@rbs!` comment must be followed by a blank line.
+
+          def bar; end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # @rbs! type foo = Integer
+
+          # @rbs @ivar: Integer
+
+          def bar; end
+        RUBY
+      end
+    end
+
+    context "when @rbs! is followed by blank line before @rbs @ivar" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          # @rbs! type foo = Integer
+
+          # @rbs @ivar: Integer
+
+          def bar; end
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/invalid_comment_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/invalid_comment_spec.rb
@@ -4,113 +4,121 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::InvalidComment, :config do
   let(:config) { RuboCop::Config.new }
 
   context "when code contains `#:` style annotation comments" do
-    it "registers an offense when using invalid annotation comments" do
-      expect_offense(<<~RUBY)
-        # () -> void
-        ^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # : () -> void
-        ^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        #: @rbs param: String
-        ^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-      RUBY
+    context "when using invalid annotation comments" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          # () -> void
+          ^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # : () -> void
+          ^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          #: @rbs param: String
+          ^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        #: () -> void
-        #: () -> void
-        # @rbs param: String
-      RUBY
+        expect_correction(<<~RUBY)
+          #: () -> void
+          #: () -> void
+          # @rbs param: String
+        RUBY
+      end
     end
 
-    it "does not register an offense when using valid annotation comments" do
-      expect_no_offenses(<<~RUBY)
-        #: () -> void
-        # a comment not related to types
-        # : a comment not related to types, but start with a colon
-        #: a comment not related to types, but start with a colon
-      RUBY
+    context "when using valid annotation comments" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          #: () -> void
+          # a comment not related to types
+          # : a comment not related to types, but start with a colon
+          #: a comment not related to types, but start with a colon
+        RUBY
+      end
     end
   end
 
   context "when code contains `# @rbs` style annotation comments" do
-    it "registers an offense when using invalid annotation comments" do
-      expect_offense(<<~RUBY)
-        # rbs return: String
-        ^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs inherits String
-        ^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs override
-        ^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs use String
-        ^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs module-self String
-        ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs generic String
-        ^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs skip
-        ^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs module String
-        ^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs class String
-        ^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs param: String
-        ^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs &block: String
-        ^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs *: String
-        ^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-        # rbs **: String
-        ^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
-      RUBY
+    context "when using invalid annotation comments" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          # rbs return: String
+          ^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs inherits String
+          ^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs override
+          ^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs use String
+          ^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs module-self String
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs generic String
+          ^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs skip
+          ^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs module String
+          ^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs class String
+          ^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs param: String
+          ^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs &block: String
+          ^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs *: String
+          ^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+          # rbs **: String
+          ^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidComment: Invalid RBS annotation comment found.
+        RUBY
 
-      expect_correction(<<~RUBY)
-        # @rbs return: String
-        # @rbs inherits String
-        # @rbs override
-        # @rbs use String
-        # @rbs module-self String
-        # @rbs generic String
-        # @rbs skip
-        # @rbs module String
-        # @rbs class String
-        # @rbs param: String
-        # @rbs &block: String
-        # @rbs *: String
-        # @rbs **: String
-      RUBY
+        expect_correction(<<~RUBY)
+          # @rbs return: String
+          # @rbs inherits String
+          # @rbs override
+          # @rbs use String
+          # @rbs module-self String
+          # @rbs generic String
+          # @rbs skip
+          # @rbs module String
+          # @rbs class String
+          # @rbs param: String
+          # @rbs &block: String
+          # @rbs *: String
+          # @rbs **: String
+        RUBY
+      end
     end
 
-    it "does not register an offense when valid annotation comments" do
-      expect_no_offenses(<<~RUBY)
-        # @rbs return: String
-        # @rbs inherits String
-        # @rbs override
-        # @rbs use String
-        # @rbs module-self String
-        # @rbs generic String
-        # @rbs in String
-        # @rbs out String
-        # @rbs unchecked String
-        # @rbs self String
-        # @rbs skip
-        # @rbs module String
-        # @rbs class String
-        # @rbs param: String
-        # @rbs &block: String
-        # @rbs *: String
-        # @rbs **: String
-        # rbs
-        # a comment not related to types
-        # rbs comment starts with "rbs"
+    context "when valid annotation comments" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          # @rbs return: String
+          # @rbs inherits String
+          # @rbs override
+          # @rbs use String
+          # @rbs module-self String
+          # @rbs generic String
+          # @rbs in String
+          # @rbs out String
+          # @rbs unchecked String
+          # @rbs self String
+          # @rbs skip
+          # @rbs module String
+          # @rbs class String
+          # @rbs param: String
+          # @rbs &block: String
+          # @rbs *: String
+          # @rbs **: String
+          # rbs
+          # a comment not related to types
+          # rbs comment starts with "rbs"
 
-        # "@rbs!" style comments are ignored.
-        # @rbs!
-        #   module MyModule
-        #     def folded_method:
-        #       (untyped, untyped) -> untyped
-        #
-        #     def method_after_blank_line: () -> void
-        #   end
-      RUBY
+          # "@rbs!" style comments are ignored.
+          # @rbs!
+          #   module MyModule
+          #     def folded_method:
+          #       (untyped, untyped) -> untyped
+          #
+          #     def method_after_blank_line: () -> void
+          #   end
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/invalid_types_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/invalid_types_spec.rb
@@ -3,59 +3,63 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::InvalidTypes, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense when using `#bad_method`" do
-    expect_offense(<<~RUBY)
-      # Comments including multibyte characters: あいうえお
+  context "when using `#bad_method`" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # Comments including multibyte characters: あいうえお
 
-      # @rbs! type t = Hash[Symbol,
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
-
-      # @rbs generic t
-      ^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
-      # @rbs module-self Hash[Symbol,
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
-      module Foo
-        include Enumerable #[Symbol,
-                           ^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
-
-        # @rbs @ivar: Hash[Symbol, String
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
-
-        # @rbs arg: Hash[Symbol, String
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
-        # @rbs *: Hash[Symbol, String
+        # @rbs! type t = Hash[Symbol,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
-        # @rbs &block: Hash[Symbol, String
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
-        #: () ->
-        ^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
-        def method(arg) #: Hash[Symbol, String
-                        ^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+
+        # @rbs generic t
+        ^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+        # @rbs module-self Hash[Symbol,
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+        module Foo
+          include Enumerable #[Symbol,
+                             ^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+
+          # @rbs @ivar: Hash[Symbol, String
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+
+          # @rbs arg: Hash[Symbol, String
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+          # @rbs *: Hash[Symbol, String
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+          # @rbs &block: Hash[Symbol, String
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+          #: () ->
+          ^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+          def method(arg) #: Hash[Symbol, String
+                          ^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/InvalidTypes: Invalid annotation found.
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 
-  it "does not register an offense when using `#good_method`" do
-    expect_no_offenses(<<~RUBY)
-      # Comments including multibyte characters: あいうえお
+  context "when using `#good_method`" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # Comments including multibyte characters: あいうえお
 
-      # @rbs! type t = Hash[Symbol, String]
+        # @rbs! type t = Hash[Symbol, String]
 
-      # @rbs generic T
-      # @rbs module-self Hash[Symbol, String]
-      module Foo
-        include Enumerable #[Symbol, String]
+        # @rbs generic T
+        # @rbs module-self Hash[Symbol, String]
+        module Foo
+          include Enumerable #[Symbol, String]
 
-        # @rbs @ivar: Hash[Symbol, String]
+          # @rbs @ivar: Hash[Symbol, String]
 
-        # @rbs arg: Hash[Symbol, String]
-        # @rbs *: Hash[Symbol, String]
-        # @rbs &block: () -> void
-        #: () -> void
-        def method(arg) #: Hash[Symbol, String]
+          # @rbs arg: Hash[Symbol, String]
+          # @rbs *: Hash[Symbol, String]
+          # @rbs &block: () -> void
+          #: () -> void
+          def method(arg) #: Hash[Symbol, String]
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/keyword_separator_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/keyword_separator_spec.rb
@@ -3,92 +3,102 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::KeywordSeparator, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense when using `:` after keyword outside a method definition" do
-    expect_offense(<<~RUBY)
-      # @rbs inherits: String
-                     ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-      # @rbs override:
-                     ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-      # @rbs use: String
-                ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-      # @rbs module-self: String
-                        ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-      # @rbs generic: String
-                    ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-      # @rbs skip:
-                 ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-      # @rbs module: String
-                   ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-      # @rbs class: String
+  context "when using `:` after keyword outside a method definition" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs inherits: String
+                       ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
+        # @rbs override:
+                       ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
+        # @rbs use: String
                   ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs inherits String
-      # @rbs override
-      # @rbs use String
-      # @rbs module-self String
-      # @rbs generic String
-      # @rbs skip
-      # @rbs module String
-      # @rbs class String
-    RUBY
-  end
-
-  it "does not register an offense when using `#good_method`" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs inherits String
-      # @rbs override
-      # @rbs use String
-      # @rbs module-self String
-      # @rbs generic String
-      # @rbs skip
-      # @rbs module String
-      # @rbs class String
-    RUBY
-  end
-
-  it "does not register an offense when a keyword is used as a parameter name before a method definition" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs override: Hash[String, untyped]
-      def meth(override); end
-
-      # @rbs inherits: Integer
-      def meth2(inherits); end
-
-      # @rbs use: Symbol
-      # @rbs skip: String
-      def meth3(use, skip); end
-    RUBY
-  end
-
-  it "registers an offense when override/skip use `:` without a type even before a method definition" do
-    expect_offense(<<~RUBY)
-      # @rbs skip:
-                 ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-      def foo; end
-
-      # @rbs override:
+        # @rbs module-self: String
+                          ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
+        # @rbs generic: String
+                      ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
+        # @rbs skip:
+                   ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
+        # @rbs module: String
                      ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
-      def bar; end
-    RUBY
+        # @rbs class: String
+                    ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      # @rbs skip
-      def foo; end
-
-      # @rbs override
-      def bar; end
-    RUBY
+      expect_correction(<<~RUBY)
+        # @rbs inherits String
+        # @rbs override
+        # @rbs use String
+        # @rbs module-self String
+        # @rbs generic String
+        # @rbs skip
+        # @rbs module String
+        # @rbs class String
+      RUBY
+    end
   end
 
-  it "does not register an offense when keyword annotations appear at both class and method level" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs inherits Bar
-      class Foo
+  context "when using `#good_method`" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs inherits String
+        # @rbs override
+        # @rbs use String
+        # @rbs module-self String
+        # @rbs generic String
+        # @rbs skip
+        # @rbs module String
+        # @rbs class String
+      RUBY
+    end
+  end
+
+  context "when a keyword is used as a parameter name before a method definition" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs override: Hash[String, untyped]
+        def meth(override); end
+
         # @rbs inherits: Integer
-        def meth(inherits); end
-      end
-    RUBY
+        def meth2(inherits); end
+
+        # @rbs use: Symbol
+        # @rbs skip: String
+        def meth3(use, skip); end
+      RUBY
+    end
+  end
+
+  context "when override/skip use `:` without a type even before a method definition" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs skip:
+                   ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
+        def foo; end
+
+        # @rbs override:
+                       ^ Style/RbsInline/KeywordSeparator: Do not use `:` after the keyword.
+        def bar; end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs skip
+        def foo; end
+
+        # @rbs override
+        def bar; end
+      RUBY
+    end
+  end
+
+  context "when keyword annotations appear at both class and method level" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs inherits Bar
+        class Foo
+          # @rbs inherits: Integer
+          def meth(inherits); end
+        end
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/method_comment_spacing_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/method_comment_spacing_spec.rb
@@ -5,364 +5,436 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::MethodCommentSpacing, :config do
     RuboCop::Config.new("Style/RbsInline/MethodCommentSpacing" => { "Enabled" => true })
   end
 
-  it "registers an offense when method annotation has blank line before method definition" do
-    expect_offense(<<~RUBY)
-      # @rbs param x: Integer
-      # @rbs return: String
+  context "when method annotation has blank line before method definition" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs param x: Integer
+        # @rbs return: String
 
-      ^{} Remove blank line between method annotation and method definition.
-      def method(x)
-      end
-    RUBY
+        ^{} Remove blank line between method annotation and method definition.
+        def method(x)
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      # @rbs param x: Integer
-      # @rbs return: String
-      def method(x)
-      end
-    RUBY
+      expect_correction(<<~RUBY)
+        # @rbs param x: Integer
+        # @rbs return: String
+        def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "registers an offense when method annotation is not followed by method definition" do
-    expect_offense(<<~RUBY)
-      # @rbs param x: Integer
-      # @rbs return: String
-      ^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
-      puts "something"
-    RUBY
+  context "when method annotation is not followed by method definition" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs param x: Integer
+        # @rbs return: String
+        ^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
+        puts "something"
+      RUBY
+    end
   end
 
-  it "registers an offense for param annotation not followed by method" do
-    expect_offense(<<~RUBY)
-      # @rbs param x: Integer
-      ^^^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
-      x = 1
-    RUBY
+  context "with a param annotation not followed by method" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs param x: Integer
+        ^^^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
+        x = 1
+      RUBY
+    end
   end
 
-  it "registers an offense for return annotation not followed by method" do
-    expect_offense(<<~RUBY)
-      # @rbs return: String
-      ^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
-      y = 2
-    RUBY
+  context "with a return annotation not followed by method" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs return: String
+        ^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
+        y = 2
+      RUBY
+    end
   end
 
-  it "does not register an offense when method annotation is immediately before method definition" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs param x: Integer
-      # @rbs return: String
-      def method(x)
-      end
-    RUBY
+  context "when method annotation is immediately before method definition" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs param x: Integer
+        # @rbs return: String
+        def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for single param annotation before method" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs param x: Integer
-      def method(x)
-      end
-    RUBY
+  context "with a single param annotation before method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs param x: Integer
+        def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for single return annotation before method" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs return: String
-      def method
-      end
-    RUBY
+  context "with a single return annotation before method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs return: String
+        def method
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for non-method @rbs annotations" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs @ivar: Integer
-      # @rbs @@cvar: Float
+  context "with non-method @rbs annotations" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs @ivar: Integer
+        # @rbs @@cvar: Float
 
-      def method
-      end
-    RUBY
+        def method
+        end
+      RUBY
+    end
   end
 
-  it "handles multiple method definitions correctly" do
-    expect_offense(<<~RUBY)
-      # @rbs param x: Integer
-      # @rbs return: String
-      def method1(x)
-      end
+  context "with multiple method definitions" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs param x: Integer
+        # @rbs return: String
+        def method1(x)
+        end
 
-      # @rbs param y: Float
+        # @rbs param y: Float
 
-      ^{} Remove blank line between method annotation and method definition.
-      def method2(y)
-      end
-    RUBY
+        ^{} Remove blank line between method annotation and method definition.
+        def method2(y)
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      # @rbs param x: Integer
-      # @rbs return: String
-      def method1(x)
-      end
+      expect_correction(<<~RUBY)
+        # @rbs param x: Integer
+        # @rbs return: String
+        def method1(x)
+        end
 
-      # @rbs param y: Float
-      def method2(y)
-      end
-    RUBY
+        # @rbs param y: Float
+        def method2(y)
+        end
+      RUBY
+    end
   end
 
-  it "handles annotation with colon after keyword" do
-    expect_offense(<<~RUBY)
-      # @rbs param: Integer
-      # @rbs return: String
+  context "with annotation with colon after keyword" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs param: Integer
+        # @rbs return: String
 
-      ^{} Remove blank line between method annotation and method definition.
-      def method
-      end
-    RUBY
+        ^{} Remove blank line between method annotation and method definition.
+        def method
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      # @rbs param: Integer
-      # @rbs return: String
-      def method
-      end
-    RUBY
+      expect_correction(<<~RUBY)
+        # @rbs param: Integer
+        # @rbs return: String
+        def method
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense when annotation is immediately before method with arguments" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs param x: Integer
-      # @rbs param y: String
-      # @rbs return: Hash[Symbol, untyped]
-      def method(x, y)
-      end
-    RUBY
+  context "when annotation is immediately before method with arguments" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs param x: Integer
+        # @rbs param y: String
+        # @rbs return: Hash[Symbol, untyped]
+        def method(x, y)
+        end
+      RUBY
+    end
   end
 
-  it "registers an offense when method type signature has blank line before method definition" do
-    expect_offense(<<~RUBY)
-      #: (Integer) -> String
+  context "when method type signature has blank line before method definition" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        #: (Integer) -> String
 
-      ^{} Remove blank line between method annotation and method definition.
-      def method(x)
-      end
-    RUBY
+        ^{} Remove blank line between method annotation and method definition.
+        def method(x)
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      #: (Integer) -> String
-      def method(x)
-      end
-    RUBY
+      expect_correction(<<~RUBY)
+        #: (Integer) -> String
+        def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "registers an offense for method type signature not followed by method" do
-    expect_offense(<<~RUBY)
-      #: (Integer) -> String
-      ^^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
-      x = 1
-    RUBY
+  context "with a method type signature not followed by method" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        #: (Integer) -> String
+        ^^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
+        x = 1
+      RUBY
+    end
   end
 
-  it "does not register an offense when method type signature is immediately before method" do
-    expect_no_offenses(<<~RUBY)
-      #: (Integer) -> String
-      def method(x)
-      end
-    RUBY
+  context "when method type signature is immediately before method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        #: (Integer) -> String
+        def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "handles mixed annotation styles correctly" do
-    expect_offense(<<~RUBY)
-      # @rbs param x: Integer
-      #: (Integer) -> String
+  context "with mixed annotation styles" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs param x: Integer
+        #: (Integer) -> String
 
-      ^{} Remove blank line between method annotation and method definition.
-      def method(x)
-      end
-    RUBY
+        ^{} Remove blank line between method annotation and method definition.
+        def method(x)
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      # @rbs param x: Integer
-      #: (Integer) -> String
-      def method(x)
-      end
-    RUBY
+      expect_correction(<<~RUBY)
+        # @rbs param x: Integer
+        #: (Integer) -> String
+        def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "registers an offense for @rbs block annotation not followed by method" do
-    expect_offense(<<~RUBY)
-      # @rbs &block: (Integer) -> void
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
-      x = 1
-    RUBY
+  context "with a @rbs block annotation not followed by method" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs &block: (Integer) -> void
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
+        x = 1
+      RUBY
+    end
   end
 
-  it "registers an offense for @rbs override annotation not followed by method" do
-    expect_offense(<<~RUBY)
-      # @rbs override
-      ^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
-      x = 1
-    RUBY
+  context "with a @rbs override annotation not followed by method" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs override
+        ^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
+        x = 1
+      RUBY
+    end
   end
 
-  it "registers an offense for @rbs %a annotation not followed by method" do
-    expect_offense(<<~RUBY)
-      # @rbs %a{pure}
-      ^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
-      x = 1
-    RUBY
+  context "with a @rbs %a annotation not followed by method" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs %a{pure}
+        ^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
+        x = 1
+      RUBY
+    end
   end
 
-  it "registers an offense for @rbs method signature not followed by method" do
-    expect_offense(<<~RUBY)
-      # @rbs (Integer) -> String
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
-      x = 1
-    RUBY
+  context "with a @rbs method signature not followed by method" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs (Integer) -> String
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
+        x = 1
+      RUBY
+    end
   end
 
-  it "does not register an offense for @rbs block annotation before method" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs &block: (Integer) -> void
-      def method
-      end
-    RUBY
+  context "with a @rbs block annotation before method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs &block: (Integer) -> void
+        def method
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for @rbs override annotation before method" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs override
-      def method
-      end
-    RUBY
+  context "with a @rbs override annotation before method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs override
+        def method
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for @rbs %a annotation before method" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs %a{pure}
-      def method
-      end
-    RUBY
+  context "with a @rbs %a annotation before method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs %a{pure}
+        def method
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for @rbs method signature before method" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs (Integer) -> String
-      def method(x)
-      end
-    RUBY
+  context "with a @rbs method signature before method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs (Integer) -> String
+        def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "registers an offense for @rbs skip annotation not followed by method" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs skip
-      x = 1
-    RUBY
+  context "with a @rbs skip annotation not followed by method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs skip
+        x = 1
+      RUBY
+    end
   end
 
-  it "does not register an offense for @rbs skip annotation before class definition" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs skip
-      class Foo; end
-    RUBY
+  context "with a @rbs skip annotation before class definition" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs skip
+        class Foo; end
+      RUBY
+    end
   end
 
-  it "does not register an offense for @rbs skip annotation before module definition" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs skip
-      module Foo; end
-    RUBY
+  context "with a @rbs skip annotation before module definition" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs skip
+        module Foo; end
+      RUBY
+    end
   end
 
-  it "registers an offense when @rbs skip annotation has blank line before class definition" do
-    expect_offense(<<~RUBY)
-      # @rbs skip
-      ^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
+  context "when @rbs skip annotation has blank line before class definition" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs skip
+        ^^^^^^^^^^^ Method-related `@rbs` annotation must be immediately before a method definition.
 
-      class Foo; end
-    RUBY
+        class Foo; end
+      RUBY
+    end
   end
 
-  it "registers an offense when @rbs skip annotation has blank line before method definition" do
-    expect_offense(<<~RUBY)
-      # @rbs skip
+  context "when @rbs skip annotation has blank line before method definition" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs skip
 
-      ^{} Remove blank line between method annotation and method definition.
-      def method
-      end
-    RUBY
+        ^{} Remove blank line between method annotation and method definition.
+        def method
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      # @rbs skip
-      def method
-      end
-    RUBY
+      expect_correction(<<~RUBY)
+        # @rbs skip
+        def method
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for @rbs skip annotation before method" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs skip
-      def method(x)
-      end
-    RUBY
+  context "with a @rbs skip annotation before method" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs skip
+        def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for trailing #: type assertion after attr_reader" do
-    expect_no_offenses(<<~RUBY)
-      attr_reader :foo #: Integer
-    RUBY
+  context "with a trailing #: type assertion after attr_reader" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        attr_reader :foo #: Integer
+      RUBY
+    end
   end
 
-  it "does not register an offense for trailing #: method type assertion after method definition" do
-    expect_no_offenses(<<~RUBY)
-      def method(x) #: (Integer) -> String
-      end
-    RUBY
+  context "with a trailing #: method type assertion after method definition" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        def method(x) #: (Integer) -> String
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for annotation before private_class_method def" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs x: Integer
-      private_class_method def self.method(x)
-      end
-    RUBY
+  context "with an annotation before private_class_method def" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs x: Integer
+        private_class_method def self.method(x)
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for annotation before private def" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs x: Integer
-      private def method(x)
-      end
-    RUBY
+  context "with an annotation before private def" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs x: Integer
+        private def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for annotation before protected def" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs x: Integer
-      protected def method(x)
-      end
-    RUBY
+  context "with an annotation before protected def" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs x: Integer
+        protected def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for annotation before module_function def" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs x: Integer
-      module_function def method(x)
-      end
-    RUBY
+  context "with an annotation before module_function def" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs x: Integer
+        module_function def method(x)
+        end
+      RUBY
+    end
   end
 
-  it "registers an offense for blank line between annotation and private_class_method def" do
-    expect_offense(<<~RUBY)
-      # @rbs x: Integer
+  context "with a blank line between annotation and private_class_method def" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs x: Integer
 
-      ^{} Remove blank line between method annotation and method definition.
-      private_class_method def self.method(x)
-      end
-    RUBY
+        ^{} Remove blank line between method annotation and method definition.
+        private_class_method def self.method(x)
+        end
+      RUBY
 
-    expect_correction(<<~RUBY)
-      # @rbs x: Integer
-      private_class_method def self.method(x)
-      end
-    RUBY
+      expect_correction(<<~RUBY)
+        # @rbs x: Integer
+        private_class_method def self.method(x)
+        end
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/missing_data_class_annotation_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/missing_data_class_annotation_spec.rb
@@ -3,183 +3,207 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::MissingDataClassAnnotation, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense and corrects each attribute missing an inline type annotation" do
-    expect_offense(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,
-        ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-        :node,
-        ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-        :visibility
-        ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-      )
-    RUBY
+  context "when each attribute is missing an inline type annotation" do
+    it "registers an offense and corrects each attribute" do
+      expect_offense(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,
+          ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+          :node,
+          ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+          :visibility
+          ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: untyped
-        :node,       #: untyped
-        :visibility  #: untyped
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: untyped
+          :node,       #: untyped
+          :visibility  #: untyped
+        )
+      RUBY
+    end
   end
 
-  it "registers an offense and corrects folded Data.define" do
-    expect_offense(<<~RUBY)
-      MethodEntry = Data.define(:name, :node, :visibility)
-                                ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-                                       ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-                                              ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-    RUBY
+  context "with a folded Data.define" do
+    it "registers an offense and corrects it" do
+      expect_offense(<<~RUBY)
+        MethodEntry = Data.define(:name, :node, :visibility)
+                                  ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+                                         ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+                                                ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+      RUBY
 
-    expect_correction(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: untyped
-        :node,       #: untyped
-        :visibility  #: untyped
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: untyped
+          :node,       #: untyped
+          :visibility  #: untyped
+        )
+      RUBY
+    end
   end
 
-  it "registers an offense and corrects only attributes without inline type annotations" do
-    expect_offense(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: Symbol
-        :node,
-        ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-        :visibility  #: Symbol
-      )
-    RUBY
+  context "when some attributes lack inline type annotations" do
+    it "registers an offense and corrects only attributes without inline type annotations" do
+      expect_offense(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: Symbol
+          :node,
+          ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+          :visibility  #: Symbol
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: Symbol
-        :node,       #: untyped
-        :visibility  #: Symbol
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: Symbol
+          :node,       #: untyped
+          :visibility  #: Symbol
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense when all attributes have inline type annotations" do
-    expect_no_offenses(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: Symbol
-        :node,       #: Parser::AST::Node
-        :visibility  #: Symbol
-      )
-    RUBY
+  context "when all attributes have inline type annotations" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: Symbol
+          :node,       #: Parser::AST::Node
+          :visibility  #: Symbol
+        )
+      RUBY
+    end
   end
 
-  it "preserves existing comments using -- syntax when correcting" do
-    expect_offense(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       # the method name
-        ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-        :node,       #: Parser::AST::Node
-        :visibility  # public, protected, or private
-        ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-      )
-    RUBY
+  context "when attributes have existing comments using -- syntax" do
+    it "preserves existing comments using -- syntax when correcting" do
+      expect_offense(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       # the method name
+          ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+          :node,       #: Parser::AST::Node
+          :visibility  # public, protected, or private
+          ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: untyped -- the method name
-        :node,       #: Parser::AST::Node
-        :visibility  #: untyped -- public, protected, or private
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: untyped -- the method name
+          :node,       #: Parser::AST::Node
+          :visibility  #: untyped -- public, protected, or private
+        )
+      RUBY
+    end
   end
 
-  it "registers an offense and corrects attributes folded on the same line inside parentheses" do
-    expect_offense(<<~RUBY)
-      MethodEntry = Data.define(
-        :name, :node, :visibility
-        ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-               ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-                      ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-      )
-    RUBY
+  context "when attributes are folded on the same line inside parentheses" do
+    it "registers an offense and corrects them" do
+      expect_offense(<<~RUBY)
+        MethodEntry = Data.define(
+          :name, :node, :visibility
+          ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+                 ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+                        ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: untyped
-        :node,       #: untyped
-        :visibility  #: untyped
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: untyped
+          :node,       #: untyped
+          :visibility  #: untyped
+        )
+      RUBY
+    end
   end
 
-  it "registers an offense and corrects attributes split across lines but not one per line" do
-    expect_offense(<<~RUBY)
-      MethodEntry = Data.define(:name, :node,
-                                ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-                                       ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-                                :visibility)
-                                ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-    RUBY
+  context "when attributes are split across lines but not one per line" do
+    it "registers an offense and corrects them" do
+      expect_offense(<<~RUBY)
+        MethodEntry = Data.define(:name, :node,
+                                  ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+                                         ^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+                                  :visibility)
+                                  ^^^^^^^^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+      RUBY
 
-    expect_correction(<<~RUBY)
-      MethodEntry = Data.define(
-        :name,       #: untyped
-        :node,       #: untyped
-        :visibility  #: untyped
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        MethodEntry = Data.define(
+          :name,       #: untyped
+          :node,       #: untyped
+          :visibility  #: untyped
+        )
+      RUBY
+    end
   end
 
-  it "registers an offense and corrects string attributes" do
-    expect_offense(<<~RUBY)
-      Point = Data.define('x', 'y')
-                          ^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-                               ^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-    RUBY
+  context "with string attributes" do
+    it "registers an offense and corrects them" do
+      expect_offense(<<~RUBY)
+        Point = Data.define('x', 'y')
+                            ^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+                                 ^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Point = Data.define(
-        'x',  #: untyped
-        'y'   #: untyped
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Point = Data.define(
+          'x',  #: untyped
+          'y'   #: untyped
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense for Data.define with no arguments" do
-    expect_no_offenses(<<~RUBY)
-      Empty = Data.define
-    RUBY
+  context "with Data.define with no arguments" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Empty = Data.define
+      RUBY
+    end
   end
 
-  it "does not register an offense for other method calls named define" do
-    expect_no_offenses(<<~RUBY)
-      Foo.define(:name, :node)
-    RUBY
+  context "with other method calls named define" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo.define(:name, :node)
+      RUBY
+    end
   end
 
-  it "does not register an offense for Struct.new" do
-    expect_no_offenses(<<~RUBY)
-      Foo = Struct.new(:name, :node)
-    RUBY
+  context "with Struct.new" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo = Struct.new(:name, :node)
+      RUBY
+    end
   end
 
-  it "handles splat argument in Data.define" do
-    expect_offense(<<~RUBY)
-      Data.define(
-        :foo,
-        ^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-        :bar,
-        ^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-        :baz,
-        ^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
-        *QUX_QUUX
-      )
-    RUBY
+  context "with a splat argument in Data.define" do
+    it "handles the splat argument" do
+      expect_offense(<<~RUBY)
+        Data.define(
+          :foo,
+          ^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+          :bar,
+          ^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+          :baz,
+          ^^^^ Style/RbsInline/MissingDataClassAnnotation: Missing inline type annotation for Data attribute (e.g., `#: Type`).
+          *QUX_QUUX
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Data.define(
-        :foo,      #: untyped
-        :bar,      #: untyped
-        :baz,      #: untyped
-        *QUX_QUUX
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Data.define(
+          :foo,      #: untyped
+          :bar,      #: untyped
+          :baz,      #: untyped
+          *QUX_QUUX
+        )
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/missing_struct_class_annotation_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/missing_struct_class_annotation_spec.rb
@@ -3,159 +3,181 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::MissingStructClassAnnotation, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense and corrects each attribute missing an inline type annotation" do
-    expect_offense(<<~RUBY)
-      Point = Struct.new(
-        :x,
-        ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-        :y,
-        ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-        :z
-        ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-      )
-    RUBY
+  context "with attributes missing inline type annotations" do
+    it "registers an offense and corrects each attribute" do
+      expect_offense(<<~RUBY)
+        Point = Struct.new(
+          :x,
+          ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+          :y,
+          ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+          :z
+          ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Point = Struct.new(
-        :x,  #: untyped
-        :y,  #: untyped
-        :z   #: untyped
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Point = Struct.new(
+          :x,  #: untyped
+          :y,  #: untyped
+          :z   #: untyped
+        )
+      RUBY
+    end
   end
 
-  it "registers an offense and corrects folded Struct.new" do
-    expect_offense(<<~RUBY)
-      Point = Struct.new(:x, :y, :z)
-                         ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-                             ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-                                 ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-    RUBY
+  context "with a folded Struct.new" do
+    it "registers an offense and corrects it" do
+      expect_offense(<<~RUBY)
+        Point = Struct.new(:x, :y, :z)
+                           ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+                               ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+                                   ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Point = Struct.new(
-        :x,  #: untyped
-        :y,  #: untyped
-        :z   #: untyped
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Point = Struct.new(
+          :x,  #: untyped
+          :y,  #: untyped
+          :z   #: untyped
+        )
+      RUBY
+    end
   end
 
-  it "registers an offense and corrects only attributes without inline type annotations" do
-    expect_offense(<<~RUBY)
-      Point = Struct.new(
-        :x,  #: Integer
-        :y,
-        ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-        :z   #: Integer
-      )
-    RUBY
+  context "with a mix of annotated and unannotated attributes" do
+    it "registers an offense and corrects only attributes without inline type annotations" do
+      expect_offense(<<~RUBY)
+        Point = Struct.new(
+          :x,  #: Integer
+          :y,
+          ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+          :z   #: Integer
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Point = Struct.new(
-        :x,  #: Integer
-        :y,  #: untyped
-        :z   #: Integer
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Point = Struct.new(
+          :x,  #: Integer
+          :y,  #: untyped
+          :z   #: Integer
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense when all attributes have inline type annotations" do
-    expect_no_offenses(<<~RUBY)
-      Point = Struct.new(
-        :x,  #: Integer
-        :y   #: Integer
-      )
-    RUBY
+  context "when all attributes have inline type annotations" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Point = Struct.new(
+          :x,  #: Integer
+          :y   #: Integer
+        )
+      RUBY
+    end
   end
 
-  it "preserves existing comments using -- syntax when correcting" do
-    expect_offense(<<~RUBY)
-      Point = Struct.new(
-        :x,  # the x coordinate
-        ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-        :y   #: Integer
-      )
-    RUBY
+  context "with existing comments using -- syntax" do
+    it "preserves existing comments using -- syntax when correcting" do
+      expect_offense(<<~RUBY)
+        Point = Struct.new(
+          :x,  # the x coordinate
+          ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+          :y   #: Integer
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Point = Struct.new(
-        :x,  #: untyped -- the x coordinate
-        :y   #: Integer
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Point = Struct.new(
+          :x,  #: untyped -- the x coordinate
+          :y   #: Integer
+        )
+      RUBY
+    end
   end
 
-  it "does not treat a leading string argument (struct name) as an attribute" do
-    expect_offense(<<~RUBY)
-      Point = Struct.new("Point", :x, :y)
-                                  ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-                                      ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-    RUBY
+  context "with a leading string argument (struct name)" do
+    it "does not treat it as an attribute" do
+      expect_offense(<<~RUBY)
+        Point = Struct.new("Point", :x, :y)
+                                    ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+                                        ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Point = Struct.new(
-        "Point",
-        :x,       #: untyped
-        :y        #: untyped
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Point = Struct.new(
+          "Point",
+          :x,       #: untyped
+          :y        #: untyped
+        )
+      RUBY
+    end
   end
 
-  it "does not treat the keyword_init: keyword argument as an attribute" do
-    expect_offense(<<~RUBY)
-      Point = Struct.new(:x, :y, keyword_init: true)
-                         ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-                             ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-    RUBY
+  context "with the keyword_init: keyword argument" do
+    it "does not treat it as an attribute" do
+      expect_offense(<<~RUBY)
+        Point = Struct.new(:x, :y, keyword_init: true)
+                           ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+                               ^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Point = Struct.new(
-        :x,                 #: untyped
-        :y,                 #: untyped
-        keyword_init: true
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Point = Struct.new(
+          :x,                 #: untyped
+          :y,                 #: untyped
+          keyword_init: true
+        )
+      RUBY
+    end
   end
 
-  it "does not register an offense for Struct.new with no arguments" do
-    expect_no_offenses(<<~RUBY)
-      Empty = Struct.new
-    RUBY
+  context "with Struct.new with no arguments" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Empty = Struct.new
+      RUBY
+    end
   end
 
-  it "does not register an offense for other method calls named new" do
-    expect_no_offenses(<<~RUBY)
-      Foo.new(:name, :node)
-    RUBY
+  context "with other method calls named new" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo.new(:name, :node)
+      RUBY
+    end
   end
 
-  it "does not register an offense for Data.define" do
-    expect_no_offenses(<<~RUBY)
-      Foo = Data.define(:name, :node)
-    RUBY
+  context "with Data.define" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo = Data.define(:name, :node)
+      RUBY
+    end
   end
 
-  it "handles splat argument in Struct.new" do
-    expect_offense(<<~RUBY)
-      Struct.new(
-        :foo,
-        ^^^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-        :bar,
-        ^^^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-        :baz,
-        ^^^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
-        *QUX_QUUX
-      )
-    RUBY
+  context "with a splat argument in Struct.new" do
+    it "handles the splat argument" do
+      expect_offense(<<~RUBY)
+        Struct.new(
+          :foo,
+          ^^^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+          :bar,
+          ^^^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+          :baz,
+          ^^^^ Style/RbsInline/MissingStructClassAnnotation: Missing inline type annotation for Struct attribute (e.g., `#: Type`).
+          *QUX_QUUX
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Struct.new(
-        :foo,      #: untyped
-        :bar,      #: untyped
-        :baz,      #: untyped
-        *QUX_QUUX
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Struct.new(
+          :foo,      #: untyped
+          :bar,      #: untyped
+          :baz,      #: untyped
+          *QUX_QUUX
+        )
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/missing_type_annotation_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/missing_type_annotation_spec.rb
@@ -519,21 +519,25 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::MissingTypeAnnotation, :config do
     end
 
     context "when method has inline #: comment" do
-      it "registers an offense when method has arguments" do
-        expect_offense(<<~RUBY)
-          def greet(name) #: String
-                    ^^^^ Missing `@rbs name:` annotation.
-            "Hello, \#{name}"
-          end
-        RUBY
+      context "when method has arguments" do
+        it "registers an offense" do
+          expect_offense(<<~RUBY)
+            def greet(name) #: String
+                      ^^^^ Missing `@rbs name:` annotation.
+              "Hello, \#{name}"
+            end
+          RUBY
+        end
       end
 
-      it "does not register an offense when method has no arguments" do
-        expect_no_offenses(<<~RUBY)
-          def greet #: String
-            "Hello"
-          end
-        RUBY
+      context "when method has no arguments" do
+        it "does not register an offense" do
+          expect_no_offenses(<<~RUBY)
+            def greet #: String
+              "Hello"
+            end
+          RUBY
+        end
       end
     end
 

--- a/spec/rubocop/cop/style/rbs_inline/parameters_separator_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/parameters_separator_spec.rb
@@ -3,68 +3,74 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::ParametersSeparator, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense when using `#bad_method`" do
-    expect_offense(<<~RUBY)
-      # @rbs param String
-             ^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
-      # @rbs &block String
-             ^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
-      # @rbs * String
-             ^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
-      # @rbs ** String
-             ^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
-      # @rbs return String
-             ^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
-      # @rbs :return String
-             ^^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
-      # @rbs :param String
-             ^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
-    RUBY
+  context "when using `#bad_method`" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs param String
+               ^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
+        # @rbs &block String
+               ^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
+        # @rbs * String
+               ^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
+        # @rbs ** String
+               ^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
+        # @rbs return String
+               ^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
+        # @rbs :return String
+               ^^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
+        # @rbs :param String
+               ^^^^^^^^^^^^^ Style/RbsInline/ParametersSeparator: Use `:` as a separator between parameter name and type.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      # @rbs param: String
-      # @rbs &block: String
-      # @rbs *: String
-      # @rbs **: String
-      # @rbs return: String
-      # @rbs return: String
-      # @rbs param: String
-    RUBY
+      expect_correction(<<~RUBY)
+        # @rbs param: String
+        # @rbs &block: String
+        # @rbs *: String
+        # @rbs **: String
+        # @rbs return: String
+        # @rbs return: String
+        # @rbs param: String
+      RUBY
+    end
   end
 
-  it "does not register an offense when using `#good_method`" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs param: String
-      # @rbs &block: String
-      # @rbs *: String
-      # @rbs **: String
-      # @rbs return: String
+  context "when using `#good_method`" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs param: String
+        # @rbs &block: String
+        # @rbs *: String
+        # @rbs **: String
+        # @rbs return: String
 
-      # @rbs %a{pure}
-      # @rbs %a[pure]
-      # @rbs %a(pure)
-      # @rbs %a{pure} %a{implicitly-returns-nil}
-      # @rbs %a{implicitly-returns-nil}
-      # @rbs %a(implicitly-returns-nil)
-      # @rbs %a[implicitly-returns-nil]
+        # @rbs %a{pure}
+        # @rbs %a[pure]
+        # @rbs %a(pure)
+        # @rbs %a{pure} %a{implicitly-returns-nil}
+        # @rbs %a{implicitly-returns-nil}
+        # @rbs %a(implicitly-returns-nil)
+        # @rbs %a[implicitly-returns-nil]
 
-      # @rbs inherits String
-      # @rbs override
-      # @rbs use String
-      # @rbs module-self String
-      # @rbs generic String
-      # @rbs skip
-      # @rbs module String
-      # @rbs class String
-    RUBY
+        # @rbs inherits String
+        # @rbs override
+        # @rbs use String
+        # @rbs module-self String
+        # @rbs generic String
+        # @rbs skip
+        # @rbs module String
+        # @rbs class String
+      RUBY
+    end
   end
 
-  it "does not register an offense for method type signature annotations" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs (Integer) -> String
-      # @rbs () -> void
-      # @rbs [T] (T) -> T
-      # @rbs [T < Parser::AST::Node] (T) -> T
-    RUBY
+  context "with method type signature annotations" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs (Integer) -> String
+        # @rbs () -> void
+        # @rbs [T] (T) -> T
+        # @rbs [T < Parser::AST::Node] (T) -> T
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/struct_class_comment_alignment_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/struct_class_comment_alignment_spec.rb
@@ -3,109 +3,127 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::StructClassCommentAlignment, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense and corrects an annotation that is too close" do
-    expect_offense(<<~RUBY)
-      Point = Struct.new(
-        :x, #: Integer
-            ^^^^^^^^^^ Style/RbsInline/StructClassCommentAlignment: Misaligned inline type annotation for Struct attribute.
-        :long_attr  #: Integer
-      )
-    RUBY
-
-    expect_correction(<<~RUBY)
-      Point = Struct.new(
-        :x,         #: Integer
-        :long_attr  #: Integer
-      )
-    RUBY
-  end
-
-  it "registers an offense and corrects an annotation that is too far" do
-    expect_offense(<<~RUBY)
-      Point = Struct.new(
-        :x,             #: Integer
-                        ^^^^^^^^^^ Style/RbsInline/StructClassCommentAlignment: Misaligned inline type annotation for Struct attribute.
-        :long_attr  #: Integer
-      )
-    RUBY
-
-    expect_correction(<<~RUBY)
-      Point = Struct.new(
-        :x,         #: Integer
-        :long_attr  #: Integer
-      )
-    RUBY
-  end
-
-  it "does not register an offense when all annotations are already aligned" do
-    expect_no_offenses(<<~RUBY)
-      Point = Struct.new(
-        :x,         #: Integer
-        :long_attr  #: Integer
-      )
-    RUBY
-  end
-
-  it "does not register an offense when there are no annotations" do
-    expect_no_offenses(<<~RUBY)
-      Point = Struct.new(
-        :x,
-        :y
-      )
-    RUBY
-  end
-
-  it "does not register an offense when only one attribute has an annotation" do
-    expect_no_offenses(<<~RUBY)
-      Point = Struct.new(
-        :x,
-        :y  #: Integer
-      )
-    RUBY
-  end
-
-  it "does not register an offense for folded Struct.new" do
-    expect_no_offenses(<<~RUBY)
-      Point = Struct.new(:x, :y, :z)
-    RUBY
-  end
-
-  it "does not register an offense for other method calls named new" do
-    expect_no_offenses(<<~RUBY)
-      Foo.new(
-        :x, #: Integer
-        :y, #: Integer
-      )
-    RUBY
-  end
-
-  it "aligns annotations accounting for a leading string argument (struct name)" do
-    expect_no_offenses(<<~RUBY)
-      Point = Struct.new(
-        "Point",
-        :x,       #: Integer
-        :y        #: Integer
-      )
-    RUBY
-  end
-
-  it "handles splat arguments correctly" do
-    expect_offense(<<~RUBY)
-      Struct.new(
-        :foo, #: Integer
+  context "with an annotation that is too close" do
+    it "registers an offense and corrects it" do
+      expect_offense(<<~RUBY)
+        Point = Struct.new(
+          :x, #: Integer
               ^^^^^^^^^^ Style/RbsInline/StructClassCommentAlignment: Misaligned inline type annotation for Struct attribute.
-        :bar, #: String
-              ^^^^^^^^^ Style/RbsInline/StructClassCommentAlignment: Misaligned inline type annotation for Struct attribute.
-        *QUX_QUUX
-      )
-    RUBY
+          :long_attr  #: Integer
+        )
+      RUBY
 
-    expect_correction(<<~RUBY)
-      Struct.new(
-        :foo,      #: Integer
-        :bar,      #: String
-        *QUX_QUUX
-      )
-    RUBY
+      expect_correction(<<~RUBY)
+        Point = Struct.new(
+          :x,         #: Integer
+          :long_attr  #: Integer
+        )
+      RUBY
+    end
+  end
+
+  context "with an annotation that is too far" do
+    it "registers an offense and corrects it" do
+      expect_offense(<<~RUBY)
+        Point = Struct.new(
+          :x,             #: Integer
+                          ^^^^^^^^^^ Style/RbsInline/StructClassCommentAlignment: Misaligned inline type annotation for Struct attribute.
+          :long_attr  #: Integer
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Point = Struct.new(
+          :x,         #: Integer
+          :long_attr  #: Integer
+        )
+      RUBY
+    end
+  end
+
+  context "when all annotations are already aligned" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Point = Struct.new(
+          :x,         #: Integer
+          :long_attr  #: Integer
+        )
+      RUBY
+    end
+  end
+
+  context "when there are no annotations" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Point = Struct.new(
+          :x,
+          :y
+        )
+      RUBY
+    end
+  end
+
+  context "when only one attribute has an annotation" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Point = Struct.new(
+          :x,
+          :y  #: Integer
+        )
+      RUBY
+    end
+  end
+
+  context "with a folded Struct.new" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Point = Struct.new(:x, :y, :z)
+      RUBY
+    end
+  end
+
+  context "with other method calls named new" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo.new(
+          :x, #: Integer
+          :y, #: Integer
+        )
+      RUBY
+    end
+  end
+
+  context "with a leading string argument (struct name)" do
+    it "aligns annotations accounting for it" do
+      expect_no_offenses(<<~RUBY)
+        Point = Struct.new(
+          "Point",
+          :x,       #: Integer
+          :y        #: Integer
+        )
+      RUBY
+    end
+  end
+
+  context "with splat arguments" do
+    it "handles them correctly" do
+      expect_offense(<<~RUBY)
+        Struct.new(
+          :foo, #: Integer
+                ^^^^^^^^^^ Style/RbsInline/StructClassCommentAlignment: Misaligned inline type annotation for Struct attribute.
+          :bar, #: String
+                ^^^^^^^^^ Style/RbsInline/StructClassCommentAlignment: Misaligned inline type annotation for Struct attribute.
+          *QUX_QUUX
+        )
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Struct.new(
+          :foo,      #: Integer
+          :bar,      #: String
+          *QUX_QUUX
+        )
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/struct_new_with_block_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/struct_new_with_block_spec.rb
@@ -3,64 +3,78 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::StructNewWithBlock, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense when Struct.new is called with a do...end block" do
-    expect_offense(<<~RUBY)
-      User = Struct.new(:name, :role) do
-             ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
-        def admin?
-          role == :admin
+  context "when Struct.new is called with a do...end block" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        User = Struct.new(:name, :role) do
+               ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+          def admin?
+            role == :admin
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 
-  it "registers an offense when Struct.new is called with a brace block" do
-    expect_offense(<<~RUBY)
-      User = Struct.new(:name, :role) { }
-             ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
-    RUBY
+  context "when Struct.new is called with a brace block" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        User = Struct.new(:name, :role) { }
+               ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+      RUBY
+    end
   end
 
-  it "registers an offense when Struct.new with no args is called with a block" do
-    expect_offense(<<~RUBY)
-      Empty = Struct.new do
-              ^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
-        def foo
-          42
+  context "when Struct.new with no args is called with a block" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        Empty = Struct.new do
+                ^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+          def foo
+            42
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 
-  it "does not register an offense when Struct.new is called without a block" do
-    expect_no_offenses(<<~RUBY)
-      User = Struct.new(:name, :role)
-    RUBY
+  context "when Struct.new is called without a block" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        User = Struct.new(:name, :role)
+      RUBY
+    end
   end
 
-  it "does not register an offense when class is reopened separately" do
-    expect_no_offenses(<<~RUBY)
-      User = Struct.new(:name, :role)
+  context "when class is reopened separately" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        User = Struct.new(:name, :role)
 
-      class User
-        def admin?
-          role == :admin
+        class User
+          def admin?
+            role == :admin
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 
-  it "does not register an offense for other new calls with a block" do
-    expect_no_offenses(<<~RUBY)
-      Foo.new(:name) do
-      end
-    RUBY
+  context "with other new calls with a block" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo.new(:name) do
+        end
+      RUBY
+    end
   end
 
-  it "does not register an offense for Data.define with a block" do
-    expect_no_offenses(<<~RUBY)
-      Foo = Data.define(:name) do
-      end
-    RUBY
+  context "with Data.define with a block" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        Foo = Data.define(:name) do
+        end
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/untyped_instance_variable_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/untyped_instance_variable_spec.rb
@@ -4,451 +4,519 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::UntypedInstanceVariable, :config 
   let(:config) { RuboCop::Config.new }
 
   context "when instance variable has no type annotation" do
-    it "does not register an offense for an ivar read (may be defined in parent class)" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          def bar
-            @baz
+    context "with an ivar read (may be defined in parent class)" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            def bar
+              @baz
+            end
           end
-        end
-      RUBY
+        RUBY
+      end
     end
 
-    it "registers an offense for an ivar assignment inside a method" do
-      expect_offense(<<~RUBY)
-        class Foo
-          def bar
-            @baz = 1
-            ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "registers an offense for multiple untyped ivar assignments" do
-      expect_offense(<<~RUBY)
-        class Foo
-          def bar
-            @baz = 1
-            ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
-            @qux = 2
-            ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@qux` is not typed. Add `# @rbs @qux: Type` or use `attr_* :qux #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "registers an offense for an ivar assignment in a module" do
-      expect_offense(<<~RUBY)
-        module Foo
-          def bar
-            @baz = 1
-            ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "registers an offense for an ivar in ||= expression" do
-      expect_offense(<<~RUBY)
-        class Foo
-          def bar
-            @baz ||= 1
-            ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "registers an offense for an ivar in initialize" do
-      expect_offense(<<~RUBY)
-        class Foo
-          def initialize
-            @baz = 1
-            ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "reports each ivar only once even if assigned multiple times" do
-      expect_offense(<<~RUBY)
-        class Foo
-          def bar
-            @baz = 1
-            ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
-          end
-
-          def baz
-            @baz = 2
-          end
-        end
-      RUBY
-    end
-
-    it "does not register an offense when ivar is only read (not assigned)" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          def bar
-            @baz
-          end
-
-          def baz
-            @baz
-          end
-        end
-      RUBY
-    end
-
-    it "does not register an offense when attr_reader has no inline type comment" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          attr_reader :baz
-
-          def bar
-            @baz
-          end
-        end
-      RUBY
-    end
-  end
-
-  context "when instance variable has a @rbs annotation" do
-    it "does not register an offense with @rbs @ivar annotation" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          # @rbs @baz: Integer
-
-          def bar
-            @baz
-          end
-        end
-      RUBY
-    end
-
-    it "does not register an offense with @rbs annotation for assignment" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          # @rbs @baz: Integer
-
-          def initialize
-            @baz = 1
-          end
-        end
-      RUBY
-    end
-
-    it "does not register an offense with multiple @rbs annotations" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          # @rbs @baz: Integer
-          # @rbs @qux: String
-
-          def initialize
-            @baz = 1
-            @qux = 'hello'
-          end
-        end
-      RUBY
-    end
-  end
-
-  context "when instance variable is covered by typed attr_*" do
-    it "does not register an offense with attr_reader and inline type" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          attr_reader :baz  #: Integer
-
-          def bar
-            @baz
-          end
-        end
-      RUBY
-    end
-
-    it "does not register an offense with attr_writer and inline type" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          attr_writer :baz  #: Integer
-
-          def bar
-            @baz = 1
-          end
-        end
-      RUBY
-    end
-
-    it "does not register an offense with attr_accessor and inline type" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          attr_accessor :baz  #: Integer
-
-          def bar
-            @baz
-          end
-        end
-      RUBY
-    end
-
-    it "does not register an offense with multiple attrs and inline types" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          attr_reader :baz, :qux  #: Integer
-
-          def bar
-            @baz
-            @qux
-          end
-        end
-      RUBY
-    end
-  end
-
-  context "with nested classes" do
-    it "registers an offense when only inner class annotates the ivar but outer assigns it" do
-      expect_offense(<<~RUBY)
-        class Outer
-          class Inner
-            # @rbs @baz: Integer
-          end
-
-          def foo
-            @baz = 1
-            ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "registers an offense for the inner class ivar when only outer is annotated" do
-      expect_offense(<<~RUBY)
-        class Outer
-          # @rbs @baz: Integer
-
-          class Inner
+    context "with an ivar assignment inside a method" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class Foo
             def bar
               @baz = 1
               ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
             end
           end
-
-          def foo
-            @baz = 1
-          end
-        end
-      RUBY
+        RUBY
+      end
     end
 
-    it "does not register an offense when each class annotates its own ivars" do
-      expect_no_offenses(<<~RUBY)
-        class Outer
-          # @rbs @baz: Integer
-
-          class Inner
-            # @rbs @baz: String
-
+    context "with multiple untyped ivar assignments" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class Foo
             def bar
-              @baz = 'hello'
+              @baz = 1
+              ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
+              @qux = 2
+              ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@qux` is not typed. Add `# @rbs @qux: Type` or use `attr_* :qux #: Type`.
             end
           end
-
-          def foo
-            @baz = 1
-          end
-        end
-      RUBY
+        RUBY
+      end
     end
 
-    it "does not register an offense when inner class ivar is typed and outer has none" do
-      expect_no_offenses(<<~RUBY)
-        class Outer
-          class Inner
+    context "with an ivar assignment in a module" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          module Foo
+            def bar
+              @baz = 1
+              ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with an ivar in ||= expression" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class Foo
+            def bar
+              @baz ||= 1
+              ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with an ivar in initialize" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class Foo
+            def initialize
+              @baz = 1
+              ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when an ivar is assigned in multiple methods" do
+      it "reports each ivar only once" do
+        expect_offense(<<~RUBY)
+          class Foo
+            def bar
+              @baz = 1
+              ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
+            end
+
+            def baz
+              @baz = 2
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when ivar is only read (not assigned)" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            def bar
+              @baz
+            end
+
+            def baz
+              @baz
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when attr_reader has no inline type comment" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            attr_reader :baz
+
+            def bar
+              @baz
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  context "when instance variable has a @rbs annotation" do
+    context "with @rbs @ivar annotation" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
             # @rbs @baz: Integer
+
+            def bar
+              @baz
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with @rbs annotation for assignment" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            # @rbs @baz: Integer
+
+            def initialize
+              @baz = 1
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with multiple @rbs annotations" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            # @rbs @baz: Integer
+            # @rbs @qux: String
+
+            def initialize
+              @baz = 1
+              @qux = 'hello'
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  context "when instance variable is covered by typed attr_*" do
+    context "with attr_reader and inline type" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            attr_reader :baz  #: Integer
+
+            def bar
+              @baz
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with attr_writer and inline type" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            attr_writer :baz  #: Integer
 
             def bar
               @baz = 1
             end
           end
-        end
-      RUBY
+        RUBY
+      end
     end
 
-    it "does not register an offense for read-only ivar in outer class" do
-      expect_no_offenses(<<~RUBY)
-        class Outer
-          class Inner
+    context "with attr_accessor and inline type" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            attr_accessor :baz  #: Integer
+
+            def bar
+              @baz
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with multiple attrs and inline types" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            attr_reader :baz, :qux  #: Integer
+
+            def bar
+              @baz
+              @qux
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  context "with nested classes" do
+    context "when only inner class annotates the ivar but outer assigns it" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class Outer
+            class Inner
+              # @rbs @baz: Integer
+            end
+
+            def foo
+              @baz = 1
+              ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when only outer is annotated but inner class assigns the ivar" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class Outer
             # @rbs @baz: Integer
-          end
 
-          def foo
-            @baz
-          end
-        end
-      RUBY
-    end
-  end
-
-  context "with top-level methods (no class)" do
-    it "registers an offense for ivar assignments outside any class" do
-      expect_offense(<<~RUBY)
-        def bar
-          @baz = 1
-          ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
-        end
-      RUBY
-    end
-
-    it "does not register an offense for ivar reads outside any class" do
-      expect_no_offenses(<<~RUBY)
-        def bar
-          @baz
-        end
-      RUBY
-    end
-
-    it "does not register an offense when top-level ivar has @rbs annotation" do
-      expect_no_offenses(<<~RUBY)
-        # @rbs @baz: Integer
-
-        def bar
-          @baz = 1
-        end
-      RUBY
-    end
-  end
-
-  context "with class-level (singleton) instance variables" do
-    it "does not register an offense with @rbs self.@ivar annotation inside `class << self`" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          # @rbs self.@instance: Foo
-
-          class << self
-            def instance
-              @instance ||= new
-            end
-          end
-        end
-      RUBY
-    end
-
-    it "does not register an offense with @rbs self.@ivar annotation inside `def self.x`" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          # @rbs self.@instance: Foo
-
-          def self.instance
-            @instance ||= new
-          end
-        end
-      RUBY
-    end
-
-    it "registers an offense for a class-level ivar assignment without annotation" do
-      expect_offense(<<~RUBY)
-        class Foo
-          class << self
-            def instance
-              @instance ||= new
-              ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Class instance variable `@instance` is not typed. Add `# @rbs self.@instance: Type` or use `attr_* :instance #: Type`.
-            end
-          end
-        end
-      RUBY
-    end
-
-    it "registers an offense for a class-level ivar assignment in `def self.x` without annotation" do
-      expect_offense(<<~RUBY)
-        class Foo
-          def self.instance
-            @instance ||= new
-            ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Class instance variable `@instance` is not typed. Add `# @rbs self.@instance: Type` or use `attr_* :instance #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "distinguishes class-level from instance-level annotations" do
-      expect_offense(<<~RUBY)
-        class Foo
-          # @rbs @instance: Foo
-
-          def self.instance
-            @instance ||= new
-            ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Class instance variable `@instance` is not typed. Add `# @rbs self.@instance: Type` or use `attr_* :instance #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "does not confuse instance-level assignment inside instance methods with class-level annotation" do
-      expect_offense(<<~RUBY)
-        class Foo
-          # @rbs self.@instance: Foo
-
-          def initialize
-            @instance = self
-            ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@instance` is not typed. Add `# @rbs @instance: Type` or use `attr_* :instance #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "does not register an offense when `class << self` attr_* declares the ivar" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          class << self
-            attr_accessor :instance  #: Foo?
-
-            def build
-              @instance ||= new
-            end
-          end
-        end
-      RUBY
-    end
-
-    it "does not treat instance-level attr_* as covering a class-level ivar" do
-      expect_offense(<<~RUBY)
-        class Foo
-          attr_accessor :instance  #: Foo?
-
-          def self.build
-            @instance ||= new
-            ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Class instance variable `@instance` is not typed. Add `# @rbs self.@instance: Type` or use `attr_* :instance #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "does not treat class-level attr_* as covering an instance-level ivar" do
-      expect_offense(<<~RUBY)
-        class Foo
-          class << self
-            attr_accessor :instance  #: Foo?
-          end
-
-          def initialize
-            @instance = self
-            ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@instance` is not typed. Add `# @rbs @instance: Type` or use `attr_* :instance #: Type`.
-          end
-        end
-      RUBY
-    end
-
-    it "treats nested class inside `class << self` as a fresh (non-singleton) context" do
-      expect_offense(<<~RUBY)
-        class Foo
-          class << self
-            class Bar
-              def initialize
+            class Inner
+              def bar
                 @baz = 1
                 ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
               end
             end
+
+            def foo
+              @baz = 1
+            end
           end
-        end
-      RUBY
+        RUBY
+      end
+    end
+
+    context "when each class annotates its own ivars" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Outer
+            # @rbs @baz: Integer
+
+            class Inner
+              # @rbs @baz: String
+
+              def bar
+                @baz = 'hello'
+              end
+            end
+
+            def foo
+              @baz = 1
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when inner class ivar is typed and outer has none" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Outer
+            class Inner
+              # @rbs @baz: Integer
+
+              def bar
+                @baz = 1
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with a read-only ivar in outer class" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Outer
+            class Inner
+              # @rbs @baz: Integer
+            end
+
+            def foo
+              @baz
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  context "with top-level methods (no class)" do
+    context "with ivar assignments outside any class" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          def bar
+            @baz = 1
+            ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
+          end
+        RUBY
+      end
+    end
+
+    context "with ivar reads outside any class" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          def bar
+            @baz
+          end
+        RUBY
+      end
+    end
+
+    context "when top-level ivar has @rbs annotation" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          # @rbs @baz: Integer
+
+          def bar
+            @baz = 1
+          end
+        RUBY
+      end
+    end
+  end
+
+  context "with class-level (singleton) instance variables" do
+    context "with @rbs self.@ivar annotation inside `class << self`" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            # @rbs self.@instance: Foo
+
+            class << self
+              def instance
+                @instance ||= new
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with @rbs self.@ivar annotation inside `def self.x`" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            # @rbs self.@instance: Foo
+
+            def self.instance
+              @instance ||= new
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with a class-level ivar assignment without annotation" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class Foo
+            class << self
+              def instance
+                @instance ||= new
+                ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Class instance variable `@instance` is not typed. Add `# @rbs self.@instance: Type` or use `attr_* :instance #: Type`.
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with a class-level ivar assignment in `def self.x` without annotation" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class Foo
+            def self.instance
+              @instance ||= new
+              ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Class instance variable `@instance` is not typed. Add `# @rbs self.@instance: Type` or use `attr_* :instance #: Type`.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with an instance-level annotation and a class-level assignment" do
+      it "distinguishes class-level from instance-level annotations" do
+        expect_offense(<<~RUBY)
+          class Foo
+            # @rbs @instance: Foo
+
+            def self.instance
+              @instance ||= new
+              ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Class instance variable `@instance` is not typed. Add `# @rbs self.@instance: Type` or use `attr_* :instance #: Type`.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with a class-level annotation but an instance-level assignment" do
+      it "does not confuse instance-level assignment inside instance methods with class-level annotation" do
+        expect_offense(<<~RUBY)
+          class Foo
+            # @rbs self.@instance: Foo
+
+            def initialize
+              @instance = self
+              ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@instance` is not typed. Add `# @rbs @instance: Type` or use `attr_* :instance #: Type`.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "when `class << self` attr_* declares the ivar" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            class << self
+              attr_accessor :instance  #: Foo?
+
+              def build
+                @instance ||= new
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with an instance-level attr_* and a class-level ivar assignment" do
+      it "does not treat instance-level attr_* as covering a class-level ivar" do
+        expect_offense(<<~RUBY)
+          class Foo
+            attr_accessor :instance  #: Foo?
+
+            def self.build
+              @instance ||= new
+              ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Class instance variable `@instance` is not typed. Add `# @rbs self.@instance: Type` or use `attr_* :instance #: Type`.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with a class-level attr_* and an instance-level ivar assignment" do
+      it "does not treat class-level attr_* as covering an instance-level ivar" do
+        expect_offense(<<~RUBY)
+          class Foo
+            class << self
+              attr_accessor :instance  #: Foo?
+            end
+
+            def initialize
+              @instance = self
+              ^^^^^^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@instance` is not typed. Add `# @rbs @instance: Type` or use `attr_* :instance #: Type`.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context "with a nested class inside `class << self`" do
+      it "treats nested class inside `class << self` as a fresh (non-singleton) context" do
+        expect_offense(<<~RUBY)
+          class Foo
+            class << self
+              class Bar
+                def initialize
+                  @baz = 1
+                  ^^^^ Style/RbsInline/UntypedInstanceVariable: Instance variable `@baz` is not typed. Add `# @rbs @baz: Type` or use `attr_* :baz #: Type`.
+                end
+              end
+            end
+          end
+        RUBY
+      end
     end
   end
 

--- a/spec/rubocop/cop/style/rbs_inline/variable_comment_spacing_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/variable_comment_spacing_spec.rb
@@ -3,214 +3,244 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::VariableCommentSpacing, :config do
   let(:config) { RuboCop::Config.new }
 
-  it "registers an offense when @rbs @ivar comment is directly followed by code" do
-    expect_offense(<<~RUBY)
-      # @rbs @ivar: Integer
-      def method
-      ^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs @ivar: Integer
-
-      def method
-      end
-    RUBY
-  end
-
-  it "registers an offense when @rbs @@cvar comment is directly followed by code" do
-    expect_offense(<<~RUBY)
-      # @rbs @@cvar: Float
-      def method
-      ^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs @@cvar: Float
-
-      def method
-      end
-    RUBY
-  end
-
-  it "registers an offense when @rbs self.@civar comment is directly followed by code" do
-    expect_offense(<<~RUBY)
-      # @rbs self.@civar: String
-      def method
-      ^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs self.@civar: String
-
-      def method
-      end
-    RUBY
-  end
-
-  it "registers an offense when multiple variable comments are directly followed by code" do
-    expect_offense(<<~RUBY)
-      # @rbs @ivar: Integer
-      # @rbs @@cvar: Float
-      # @rbs self.@civar: String
-      def method
-      ^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs @ivar: Integer
-      # @rbs @@cvar: Float
-      # @rbs self.@civar: String
-
-      def method
-      end
-    RUBY
-  end
-
-  it "does not register an offense when @rbs @ivar comment is followed by a blank line" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs @ivar: Integer
-
-      def method
-      end
-    RUBY
-  end
-
-  it "does not register an offense when multiple variable comments are followed by a blank line" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs @ivar: Integer
-      # @rbs @@cvar: Float
-      # @rbs self.@civar: String
-
-      def method
-      end
-    RUBY
-  end
-
-  it "does not register an offense when @rbs variable comment is at the end of file" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs @ivar: Integer
-    RUBY
-  end
-
-  it "registers an offense when @rbs variable comment is followed by a class definition" do
-    expect_offense(<<~RUBY)
-      # @rbs @ivar: Integer
-      class Foo
-      ^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs @ivar: Integer
-
-      class Foo
-      end
-    RUBY
-  end
-
-  it "does not register an offense with multiple variable comment blocks properly spaced" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs @ivar1: Integer
-
-      def method1
-      end
-
-      # @rbs @ivar2: String
-
-      def method2
-      end
-    RUBY
-  end
-
-  it "does not register an offense for non-variable @rbs comments" do
-    expect_no_offenses(<<~RUBY)
-      # @rbs return: Integer
-      def method
-      end
-    RUBY
-  end
-
-  it "registers an offense when variable comment is followed by module definition" do
-    expect_offense(<<~RUBY)
-      # @rbs @@config: Hash[Symbol, untyped]
-      module Config
-      ^^^^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      # @rbs @@config: Hash[Symbol, untyped]
-
-      module Config
-      end
-    RUBY
-  end
-
-  context "with consecutive @rbs variable comments and other @rbs comments" do
-    it "registers an offense when @rbs variable is followed by method annotation without blank line" do
+  context "when @rbs @ivar comment is directly followed by code" do
+    it "registers an offense" do
       expect_offense(<<~RUBY)
         # @rbs @ivar: Integer
-        # @rbs return: String
-        ^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
-        def bar; end
+        def method
+        ^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
+        end
       RUBY
 
       expect_correction(<<~RUBY)
         # @rbs @ivar: Integer
 
-        # @rbs return: String
-        def bar; end
+        def method
+        end
       RUBY
     end
+  end
 
-    it "does not register an offense when @rbs variable is followed by blank line before method annotation" do
+  context "when @rbs @@cvar comment is directly followed by code" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs @@cvar: Float
+        def method
+        ^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs @@cvar: Float
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when @rbs self.@civar comment is directly followed by code" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs self.@civar: String
+        def method
+        ^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs self.@civar: String
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when multiple variable comments are directly followed by code" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs @ivar: Integer
+        # @rbs @@cvar: Float
+        # @rbs self.@civar: String
+        def method
+        ^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs @ivar: Integer
+        # @rbs @@cvar: Float
+        # @rbs self.@civar: String
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when @rbs @ivar comment is followed by a blank line" do
+    it "does not register an offense" do
       expect_no_offenses(<<~RUBY)
         # @rbs @ivar: Integer
 
-        # @rbs return: String
-        def bar; end
+        def method
+        end
       RUBY
+    end
+  end
+
+  context "when multiple variable comments are followed by a blank line" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs @ivar: Integer
+        # @rbs @@cvar: Float
+        # @rbs self.@civar: String
+
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when @rbs variable comment is at the end of file" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs @ivar: Integer
+      RUBY
+    end
+  end
+
+  context "when @rbs variable comment is followed by a class definition" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs @ivar: Integer
+        class Foo
+        ^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs @ivar: Integer
+
+        class Foo
+        end
+      RUBY
+    end
+  end
+
+  context "with multiple variable comment blocks properly spaced" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs @ivar1: Integer
+
+        def method1
+        end
+
+        # @rbs @ivar2: String
+
+        def method2
+        end
+      RUBY
+    end
+  end
+
+  context "with non-variable @rbs comments" do
+    it "does not register an offense" do
+      expect_no_offenses(<<~RUBY)
+        # @rbs return: Integer
+        def method
+        end
+      RUBY
+    end
+  end
+
+  context "when variable comment is followed by module definition" do
+    it "registers an offense" do
+      expect_offense(<<~RUBY)
+        # @rbs @@config: Hash[Symbol, untyped]
+        module Config
+        ^^^^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        # @rbs @@config: Hash[Symbol, untyped]
+
+        module Config
+        end
+      RUBY
+    end
+  end
+
+  context "with consecutive @rbs variable comments and other @rbs comments" do
+    context "when @rbs variable is followed by method annotation without blank line" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          # @rbs @ivar: Integer
+          # @rbs return: String
+          ^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
+          def bar; end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          # @rbs @ivar: Integer
+
+          # @rbs return: String
+          def bar; end
+        RUBY
+      end
+    end
+
+    context "when @rbs variable is followed by blank line before method annotation" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          # @rbs @ivar: Integer
+
+          # @rbs return: String
+          def bar; end
+        RUBY
+      end
     end
   end
 
   context "with class definitions" do
-    it "registers an offense when variable comments inside class are directly followed by method" do
-      expect_offense(<<~RUBY)
-        class Foo
-          # @rbs @ivar: Integer
-          # @rbs @@cvar: Float
-          def method
-        ^^^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
+    context "when variable comments inside class are directly followed by method" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          class Foo
+            # @rbs @ivar: Integer
+            # @rbs @@cvar: Float
+            def method
+          ^^^^^^^^^^^^ Style/RbsInline/VariableCommentSpacing: `@rbs` variable comment must be followed by a blank line.
+            end
           end
-        end
-      RUBY
+        RUBY
 
-      expect_correction(<<~RUBY)
-        class Foo
-          # @rbs @ivar: Integer
-          # @rbs @@cvar: Float
+        expect_correction(<<~RUBY)
+          class Foo
+            # @rbs @ivar: Integer
+            # @rbs @@cvar: Float
 
-          def method
+            def method
+            end
           end
-        end
-      RUBY
+        RUBY
+      end
     end
 
-    it "does not register an offense when properly spaced inside class" do
-      expect_no_offenses(<<~RUBY)
-        class Foo
-          # @rbs @ivar: Integer
-          # @rbs @@cvar: Float
+    context "when properly spaced inside class" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          class Foo
+            # @rbs @ivar: Integer
+            # @rbs @@cvar: Float
 
-          def method
+            def method
+            end
           end
-        end
-      RUBY
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Refactored multiple RBS::Inline cop spec files to use RSpec's `context` and nested `it` blocks instead of flat `it` blocks. This improves test organization and readability by grouping related test cases under descriptive contexts.

## Changes

- **method_comment_spacing_spec.rb**: Reorganized 30+ test cases into logical context groups (e.g., "when method annotation has blank line before method definition", "when method annotation is not followed by method definition")
- **untyped_instance_variable_spec.rb**: Grouped tests into contexts like "when instance variable has no type annotation" and "when instance variable has a @rbs annotation" with nested scenarios
- **missing_data_class_annotation_spec.rb**: Organized tests into contexts for different Data.define scenarios
- **variable_comment_spacing_spec.rb**: Grouped variable comment spacing tests by annotation type and behavior
- **embedded_rbs_spacing_spec.rb**: Organized @rbs! comment spacing tests into logical contexts
- **missing_struct_class_annotation_spec.rb**: Grouped Struct attribute annotation tests
- **data_class_comment_alignment_spec.rb**: Organized alignment tests by scenario type
- **struct_class_comment_alignment_spec.rb**: Similar alignment test organization
- **invalid_comment_spec.rb**: Grouped invalid comment tests by annotation style
- **keyword_separator_spec.rb**: Organized keyword separator tests
- **parameters_separator_spec.rb**: Grouped parameter separator tests
- **data_define_with_block_spec.rb**: Organized Data.define block tests
- **struct_new_with_block_spec.rb**: Organized Struct.new block tests
- **invalid_types_spec.rb**: Grouped invalid type annotation tests
- **missing_type_annotation_spec.rb**: Partial refactoring of type annotation tests

## Implementation Details

- All test assertions and expectations remain unchanged; only the organizational structure was modified
- Indentation was adjusted to reflect the nested context/it structure
- Test descriptions were refined to work as context descriptions (e.g., "when X" for contexts, "registers an offense" for it blocks)
- No changes to actual cop implementations or test logic

https://claude.ai/code/session_01XaYquWm2QTJWCRJZju9xcY