### PR TITLE
Add self-review hook before git commit

### DIFF
--- a/.claude/hooks/self-review.sh
+++ b/.claude/hooks/self-review.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# PreToolUse hook: review code before `git commit`.
+#
+# Fires before a Bash `git commit` command and blocks the first commit attempt
+# for a given change-set, asking Claude to review the code before committing.
+# The review uses the `self-review` skill when available, and falls back to the
+# bundled `code-review` skill otherwise — so the hook works even in projects
+# that don't ship the custom self-review skill.
+#
+# A per-change-set marker (keyed by a hash of the diff, stored under .git/)
+# prevents an infinite block loop: once a change-set has been surfaced for
+# review, the matching commit is allowed through. If the review leads to fixes,
+# the diff changes, so the new state is reviewed once more before it commits.
+#
+
+set -euo pipefail
+
+# Read JSON input from stdin
+input=$(cat)
+
+tool_name=$(echo "$input" | jq -r '.tool_name // empty')
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+# Only gate the Bash tool running a git commit.
+if [[ "$tool_name" != "Bash" ]]; then
+  exit 0
+fi
+# Match `git commit`, or `git -C <path> commit`.
+commit_re='git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?commit'
+if [[ ! "$command" =~ $commit_re ]]; then
+  exit 0
+fi
+
+# If the command targets a specific repo via `git -C <path>`, operate there too.
+work_dir="."
+if [[ "$command" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  work_dir="${BASH_REMATCH[1]}"
+fi
+
+# Not a git repo → nothing to do.
+git_dir=$(git -C "$work_dir" rev-parse --absolute-git-dir 2>/dev/null || true)
+if [[ -z "$git_dir" ]]; then
+  exit 0
+fi
+
+# Hash what will be committed. `git status --porcelain` is included so a commit
+# that only adds untracked files isn't mistaken for empty; `git diff HEAD` adds
+# tracked content. On the first commit there is no HEAD, so use the working state.
+if git -C "$work_dir" rev-parse --verify HEAD >/dev/null 2>&1; then
+  changeset=$(git -C "$work_dir" status --porcelain; git -C "$work_dir" diff HEAD)
+else
+  changeset=$(git -C "$work_dir" status --porcelain; git -C "$work_dir" diff; git -C "$work_dir" diff --cached)
+fi
+
+# Nothing to review (e.g. a message-only `--amend`) → let it proceed.
+if [[ -z "$changeset" ]]; then
+  exit 0
+fi
+
+hash=$(printf '%s' "$changeset" | git hash-object --stdin)
+state_file="$git_dir/self-review-reviewed"
+
+# Already surfaced for review → allow the commit.
+if [[ -f "$state_file" ]] && grep -qxF "$hash" "$state_file"; then
+  exit 0
+fi
+
+# Record this change-set and block once to force a review first.
+echo "$hash" >> "$state_file"
+
+review_prompt='SELF-REVIEW REQUIRED before committing. Review the changes that are
+about to be committed BEFORE running git commit again:
+
+- If the `self-review` skill is available, invoke it (Skill tool, skill "self-review").
+- Otherwise, run the bundled `/code-review` skill on the working diff.
+
+If the review finds issues, fix them and review again. Once it is clean, run the same
+git commit command again to proceed — it will be allowed through.'
+
+jq -n --arg reason "$review_prompt" '{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": $reason
+  }
+}'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,11 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/self-review.sh",
+            "timeout": 10000
           }
         ]
       }


### PR DESCRIPTION
## Summary

Sets up the `self-review.sh` PreToolUse hook from the `setup-dev-workflow-hooks` skill so that changes get reviewed before they are committed.

- `.claude/hooks/self-review.sh` — blocks the first commit attempt for a given change-set and asks for a review (uses the `self-review` skill when available, falls back to the bundled `/code-review`). A per-change-set marker under `.git/` lets the retry through, so there is no infinite block loop.
- `.claude/settings.json` — registers the hook in the existing `PreToolUse` / `Bash` group next to `pre-commit-check.sh`. `SessionStart`, `PostToolUse` and `permissions` are unchanged (`RemoteTrigger` was already allowed).

The script is a verbatim copy of the skill template, so its style (2-space indent, long header comment) differs from the existing hooks in this repo. Keeping it byte-identical avoids drift from upstream.

## Test plan

Verified in a throwaway git repository by feeding the hook its JSON input directly:

- non-commit command (`git status`) → no output, passes through
- 1st commit attempt → `permissionDecision: "deny"` requesting a self-review
- 2nd attempt with the same change-set → passes through (no infinite block)

Also exercised end-to-end while committing this change: the first attempt was denied, the retry went through.

No test code is added, so there are no new specs.

## Known trade-offs

- `pre-commit-check.sh` and `self-review.sh` share one `PreToolUse` group. PreToolUse hooks run in parallel and a deny from one does not stop the other, so `bundle exec rake` runs on both the denied attempt and the retry. Accepted for now.
- `timeout: 10000` comes from the skill template. The hook `timeout` is in seconds, so this is effectively no timeout; the script only shells out to `git` and `jq`. Left as-is to stay identical to the template — worth fixing upstream in the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
