### PR TITLE
Extract method_parameter_list_end_line to ASTUtils

### DIFF
--- a/lib/rubocop/cop/style/rbs_inline/missing_type_annotation.rb
+++ b/lib/rubocop/cop/style/rbs_inline/missing_type_annotation.rb
@@ -349,21 +349,6 @@ module RuboCop
             add_offense(node, message: ATTRIBUTE_METHOD_MESSAGE)
           end
 
-          # Returns the last line of the method parameter list (the closing ) line, or the def line if no parens).
-          # @rbs node: RuboCop::AST::DefNode
-          def method_parameter_list_end_line(node) #: Integer
-            args_node = args_node_for(node)
-            end_line(args_node, default: node.location.line)
-          end
-
-          # @rbs node: RuboCop::AST::DefNode
-          def args_node_for(node) #: RuboCop::AST::Node
-            case node.type
-            when :defs then node.children[2]
-            else node.children[1]
-            end
-          end
-
           # @rbs node: RuboCop::AST::DefNode
           def method_has_arguments?(node) #: bool
             args_node_for(node).children.any?

--- a/lib/rubocop/cop/style/rbs_inline/mixin/ast_utils.rb
+++ b/lib/rubocop/cop/style/rbs_inline/mixin/ast_utils.rb
@@ -12,6 +12,22 @@ module RuboCop
             location.end&.line || default
           end
 
+          # Returns the arguments node of a method definition.
+          # @rbs node: RuboCop::AST::DefNode
+          def args_node_for(node) #: RuboCop::AST::Node
+            case node.type
+            when :def  then node.children[1]
+            when :defs then node.children[2]
+            else raise
+            end
+          end
+
+          # Returns the last line of the method parameter list (the closing ) line, or the def line if no parens).
+          # @rbs node: RuboCop::AST::DefNode
+          def method_parameter_list_end_line(node) #: Integer
+            end_line(args_node_for(node), default: node.location.line)
+          end
+
           # @rbs node: RuboCop::AST::Node
           def name_location(node) #: untyped
             location = node.location #: untyped

--- a/lib/rubocop/cop/style/rbs_inline/redundant_annotation_with_skip.rb
+++ b/lib/rubocop/cop/style/rbs_inline/redundant_annotation_with_skip.rb
@@ -60,6 +60,7 @@ module RuboCop
         class RedundantAnnotationWithSkip < Base
           prepend FileFilter
           extend AutoCorrector
+          include ASTUtils
           include CommentParser
           include RangeHelp
           include SourceCodeHelper
@@ -182,17 +183,6 @@ module RuboCop
               removal_range = range_with_surrounding_space(range: comment.loc.expression, side: :left, newlines: false)
               corrector.remove(removal_range)
             end
-          end
-
-          # Returns the last line of the method parameter list (the closing ) line, or the def line if no parens).
-          # @rbs node: RuboCop::AST::DefNode
-          def method_parameter_list_end_line(node) #: Integer
-            args_node = case node.type
-                        when :def  then node.children[1]
-                        when :defs then node.children[2]
-                        else raise
-                        end
-            args_node.location.end&.line || node.location.line
           end
         end
       end

--- a/lib/rubocop/cop/style/rbs_inline/redundant_type_annotation.rb
+++ b/lib/rubocop/cop/style/rbs_inline/redundant_type_annotation.rb
@@ -82,6 +82,7 @@ module RuboCop
         class RedundantTypeAnnotation < Base
           prepend FileFilter
           extend AutoCorrector
+          include ASTUtils
           include CommentParser
           include ConfigurableEnforcedStyle
           include RangeHelp
@@ -128,17 +129,6 @@ module RuboCop
             when :doc_style, :doc_style_and_return_annotation
               add_offense_for_method_type_signature(method_type_signature_comments)
             end
-          end
-
-          # Returns the last line of the method parameter list (the closing ) line, or the def line if no parens).
-          # @rbs node: RuboCop::AST::DefNode
-          def method_parameter_list_end_line(node) #: Integer
-            args_node = case node.type
-                        when :def  then node.children[1]
-                        when :defs then node.children[2]
-                        else raise
-                        end
-            args_node.location.end&.line || node.location.line
           end
 
           # @rbs def_line: Integer

--- a/sig/rubocop/cop/style/rbs_inline/missing_type_annotation.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/missing_type_annotation.rbs
@@ -230,13 +230,6 @@ module RuboCop
           # @rbs node: RuboCop::AST::SendNode
           def check_attribute_method: (RuboCop::AST::SendNode node) -> void
 
-          # Returns the last line of the method parameter list (the closing ) line, or the def line if no parens).
-          # @rbs node: RuboCop::AST::DefNode
-          def method_parameter_list_end_line: (RuboCop::AST::DefNode node) -> Integer
-
-          # @rbs node: RuboCop::AST::DefNode
-          def args_node_for: (RuboCop::AST::DefNode node) -> RuboCop::AST::Node
-
           # @rbs node: RuboCop::AST::DefNode
           def method_has_arguments?: (RuboCop::AST::DefNode node) -> bool
 

--- a/sig/rubocop/cop/style/rbs_inline/mixin/ast_utils.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/mixin/ast_utils.rbs
@@ -9,6 +9,14 @@ module RuboCop
           # @rbs default: Integer
           def end_line: (RuboCop::AST::Node node, default: Integer) -> Integer
 
+          # Returns the arguments node of a method definition.
+          # @rbs node: RuboCop::AST::DefNode
+          def args_node_for: (RuboCop::AST::DefNode node) -> RuboCop::AST::Node
+
+          # Returns the last line of the method parameter list (the closing ) line, or the def line if no parens).
+          # @rbs node: RuboCop::AST::DefNode
+          def method_parameter_list_end_line: (RuboCop::AST::DefNode node) -> Integer
+
           # @rbs node: RuboCop::AST::Node
           def name_location: (RuboCop::AST::Node node) -> untyped
 

--- a/sig/rubocop/cop/style/rbs_inline/redundant_annotation_with_skip.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/redundant_annotation_with_skip.rbs
@@ -59,6 +59,8 @@ module RuboCop
 
           extend AutoCorrector
 
+          include ASTUtils
+
           include CommentParser
 
           include RangeHelp
@@ -107,10 +109,6 @@ module RuboCop
 
           # @rbs param_list_end_line: Integer
           def check_trailing_return: (Integer param_list_end_line) -> void
-
-          # Returns the last line of the method parameter list (the closing ) line, or the def line if no parens).
-          # @rbs node: RuboCop::AST::DefNode
-          def method_parameter_list_end_line: (RuboCop::AST::DefNode node) -> Integer
         end
       end
     end

--- a/sig/rubocop/cop/style/rbs_inline/redundant_type_annotation.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/redundant_type_annotation.rbs
@@ -81,6 +81,8 @@ module RuboCop
 
           extend AutoCorrector
 
+          include ASTUtils
+
           include CommentParser
 
           include ConfigurableEnforcedStyle
@@ -111,10 +113,6 @@ module RuboCop
 
           # @rbs def_line: Integer
           def check_parameter_redundancy: (Integer def_line) -> void
-
-          # Returns the last line of the method parameter list (the closing ) line, or the def line if no parens).
-          # @rbs node: RuboCop::AST::DefNode
-          def method_parameter_list_end_line: (RuboCop::AST::DefNode node) -> Integer
 
           # @rbs def_line: Integer
           # @rbs parameter_list_end_line: Integer


### PR DESCRIPTION
## Summary

Consolidates duplicate implementations of `method_parameter_list_end_line` and `args_node_for` helper methods by moving them to the shared `ASTUtils` module. This eliminates code duplication across three cop classes and improves maintainability.

## Key Changes

- **ASTUtils**: Added `args_node_for` and `method_parameter_list_end_line` methods with proper handling for both `:def` and `:defs` node types
- **MissingTypeAnnotation**: Removed duplicate implementations of both methods; still uses them via inheritance
- **RedundantAnnotationWithSkip**: Removed duplicate `method_parameter_list_end_line` implementation; now includes `ASTUtils`
- **RedundantTypeAnnotation**: Removed duplicate `method_parameter_list_end_line` implementation; now includes `ASTUtils`
- **Type signatures**: Updated `.rbs` files to reflect the new module organization

## Implementation Details

The `args_node_for` method properly handles both method definition types:
- `:def` (regular methods): arguments at `node.children[1]`
- `:defs` (singleton methods): arguments at `node.children[2]`

The `method_parameter_list_end_line` method uses `args_node_for` and falls back to the method definition line when no parentheses are present.

https://claude.ai/code/session_016e67kfxZEyJchU72FQ2APs