### PR TITLE
Extract RBS_INLINE_KEYWORDS into a shared AnnotationKeywords mixin

### DIFF
--- a/lib/rubocop/cop/rbs_inline_cops.rb
+++ b/lib/rubocop/cop/rbs_inline_cops.rb
@@ -3,6 +3,7 @@
 # Mixins first, in dependency order. Cops follow, alphabetically: `rake new_cop` sorts a
 # generated require only against the others in the same directory, so the two blocks have
 # to stay apart for it to land in the right place.
+require_relative "style/rbs_inline/mixin/annotation_keywords"
 require_relative "style/rbs_inline/mixin/ast_utils"
 require_relative "style/rbs_inline/mixin/source_code_helper"
 require_relative "style/rbs_inline/mixin/comment_parser"

--- a/lib/rubocop/cop/style/rbs_inline/invalid_comment.rb
+++ b/lib/rubocop/cop/style/rbs_inline/invalid_comment.rb
@@ -22,11 +22,10 @@ module RuboCop
         class InvalidComment < Base
           prepend FileFilter
           extend AutoCorrector
+          include AnnotationKeywords
 
           MSG = "Invalid RBS annotation comment found."
 
-          # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
-          RBS_INLINE_KEYWORDS = %w[inherits override use module-self generic skip module class].freeze #: Array[String]
           RBS_INLINE_KEYWORD_PATTERN = RBS_INLINE_KEYWORDS.join("|") #: String
 
           SIGNATURE_PATTERN = '\(.*\)\s*(\??\s*{.*?}\s*)?->\s*.*'

--- a/lib/rubocop/cop/style/rbs_inline/keyword_separator.rb
+++ b/lib/rubocop/cop/style/rbs_inline/keyword_separator.rb
@@ -17,13 +17,12 @@ module RuboCop
         class KeywordSeparator < Base
           prepend FileFilter
           extend AutoCorrector
+          include AnnotationKeywords
           include CommentParser
           include RangeHelp
 
           MSG = "Do not use `:` after the keyword."
 
-          # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
-          RBS_INLINE_KEYWORDS = %w[inherits override use module-self generic skip module class].freeze #: Array[String]
           # `override` and `skip` are standalone markers that take no arguments.
           # Even before a method definition they may not be followed by `:` alone,
           # because `# @rbs override:` (no type) is not a valid parameter annotation.

--- a/lib/rubocop/cop/style/rbs_inline/mixin/annotation_keywords.rb
+++ b/lib/rubocop/cop/style/rbs_inline/mixin/annotation_keywords.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      module RbsInline
+        # Provides the list of keywords that may follow `# @rbs` in an annotation comment.
+        #
+        # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
+        module AnnotationKeywords
+          RBS_INLINE_KEYWORDS = %w[inherits override use module-self generic skip module class].freeze #: Array[String]
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/style/rbs_inline/parameters_separator.rb
+++ b/lib/rubocop/cop/style/rbs_inline/parameters_separator.rb
@@ -22,12 +22,11 @@ module RuboCop
         class ParametersSeparator < Base
           prepend FileFilter
           extend AutoCorrector
+          include AnnotationKeywords
           include RangeHelp
 
           MSG = "Use `:` as a separator between parameter name and type."
 
-          # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
-          RBS_INLINE_KEYWORDS = %w[inherits override use module-self generic skip module class].freeze #: Array[String]
           RBS_INLINE_REGEXP_KEYWORDS = [/%a{(\w|-)+}/, /%a\((\w|-)+\)/, /%a\[(\w|-)+\]/].freeze #: Array[Regexp]
 
           def on_new_investigation #: void

--- a/sig/rubocop/cop/style/rbs_inline/invalid_comment.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/invalid_comment.rbs
@@ -21,10 +21,9 @@ module RuboCop
 
           extend AutoCorrector
 
-          MSG: ::String
+          include AnnotationKeywords
 
-          # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
-          RBS_INLINE_KEYWORDS: Array[String]
+          MSG: ::String
 
           RBS_INLINE_KEYWORD_PATTERN: String
 

--- a/sig/rubocop/cop/style/rbs_inline/keyword_separator.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/keyword_separator.rbs
@@ -18,14 +18,13 @@ module RuboCop
 
           extend AutoCorrector
 
+          include AnnotationKeywords
+
           include CommentParser
 
           include RangeHelp
 
           MSG: ::String
-
-          # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
-          RBS_INLINE_KEYWORDS: Array[String]
 
           # `override` and `skip` are standalone markers that take no arguments.
           # Even before a method definition they may not be followed by `:` alone,

--- a/sig/rubocop/cop/style/rbs_inline/mixin/annotation_keywords.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/mixin/annotation_keywords.rbs
@@ -1,0 +1,16 @@
+# Generated from lib/rubocop/cop/style/rbs_inline/mixin/annotation_keywords.rb with RBS::Inline
+
+module RuboCop
+  module Cop
+    module Style
+      module RbsInline
+        # Provides the list of keywords that may follow `# @rbs` in an annotation comment.
+        #
+        # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
+        module AnnotationKeywords
+          RBS_INLINE_KEYWORDS: Array[String]
+        end
+      end
+    end
+  end
+end

--- a/sig/rubocop/cop/style/rbs_inline/parameters_separator.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/parameters_separator.rbs
@@ -24,12 +24,11 @@ module RuboCop
 
           extend AutoCorrector
 
+          include AnnotationKeywords
+
           include RangeHelp
 
           MSG: ::String
-
-          # refs: https://github.com/soutaro/rbs-inline/blob/main/lib/rbs/inline/annotation_parser/tokenizer.rb
-          RBS_INLINE_KEYWORDS: Array[String]
 
           RBS_INLINE_REGEXP_KEYWORDS: Array[Regexp]
 


### PR DESCRIPTION
## Summary

`RBS_INLINE_KEYWORDS` was defined identically — along with its `# refs:` comment — in three cop classes. This extracts it into a single shared mixin.

## Changes

- **New mixin**: `lib/rubocop/cop/style/rbs_inline/mixin/annotation_keywords.rb` defines `AnnotationKeywords`, holding the `RBS_INLINE_KEYWORDS` constant and the `# refs:` pointer to rbs-inline's tokenizer.
- **Updated cops**: removed the duplicate definition from `InvalidComment`, `KeywordSeparator` and `ParametersSeparator`; each now does `include AnnotationKeywords`.
- **Updated signatures**: regenerated `sig/` via `rake rbs:generate`.
- **Updated loader**: added the require to the mixin block in `lib/rubocop/cop/rbs_inline_cops.rb`.

Cop-specific constants stay where they are: `RBS_INLINE_KEYWORD_PATTERN` (InvalidComment), `NO_ARGUMENT_KEYWORDS` (KeywordSeparator) and `RBS_INLINE_REGEXP_KEYWORDS` (ParametersSeparator).

## Verification

`bundle exec rake` is green — 61 files inspected / no offenses, 431 examples / 0 failures, no Steep type error, `rbs validate` clean.

https://claude.ai/code/session_01ELjxnGKVb8sVtbVUrkH9N1