### PR TITLE
Fix --auto-gen-config generating an unusable EnforcedStyle for RedundantTypeAnnotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - **Style/RbsInline/UnmatchedAnnotations**: Fixed a crash on method definitions taking a destructuring argument (ex. `def foo((a, b))`). The crash also aborted the inspection of the method definition, causing false positives on its valid annotations.
 - **Style/RbsInline/RequireRbsInlineComment**: Fixed a crash (`IndexError`) on a file whose leading comment block ends without a trailing newline. The offense is now reported and the magic comment is inserted on its own line.
+- **Style/RbsInline/RedundantTypeAnnotation**: Fixed `--auto-gen-config` generating an `EnforcedStyle` that does not resolve the offenses (including the unsupported `return_type_annotation`, which made RuboCop fail to start on the generated `.rubocop_todo.yml`). No style can make redundant annotations offense-free, so the offending files are now excluded instead.
 
 ### Deprecations
 

--- a/lib/rubocop/cop/style/rbs_inline/redundant_type_annotation.rb
+++ b/lib/rubocop/cop/style/rbs_inline/redundant_type_annotation.rb
@@ -156,7 +156,7 @@ module RuboCop
             last = comments.last or return
             range = first.loc.expression.join(last.loc.expression)
             add_offense(range, message: MSG_METHOD_TYPE_SIGNATURE) do |corrector|
-              unexpected_style_detected(:method_type_signature)
+              no_acceptable_style!
               corrector.remove(range_by_whole_lines(range, include_final_newline: true))
             end
           end
@@ -169,7 +169,7 @@ module RuboCop
           def add_offense_for_doc_style_param(annotation) #: void
             range = annotation_range(annotation) or return
             add_offense(range, message: MSG_DOC_STYLE_PARAM) do |corrector|
-              unexpected_style_detected(:doc_style)
+              no_acceptable_style!
               corrector.remove(range_by_whole_lines(range, include_final_newline: true))
             end
           end
@@ -190,7 +190,7 @@ module RuboCop
           # @rbs comment: Parser::Source::Comment
           def add_offense_for_trailing_return(comment) #: void
             add_offense(comment, message: MSG_TRAILING_RETURN) do |corrector|
-              unexpected_style_detected(:return_type_annotation)
+              no_acceptable_style!
               removal_range = range_with_surrounding_space(range: comment.loc.expression, side: :left, newlines: false)
               corrector.remove(removal_range)
             end
@@ -200,7 +200,7 @@ module RuboCop
           def add_offense_for_doc_style_return(annotation) #: void
             range = annotation_range(annotation) or return
             add_offense(range, message: MSG_DOC_STYLE_RETURN) do |corrector|
-              unexpected_style_detected(:doc_style)
+              no_acceptable_style!
               corrector.remove(range_by_whole_lines(range, include_final_newline: true))
             end
           end

--- a/sig/gems/rubocop/rubocop.rbs
+++ b/sig/gems/rubocop/rubocop.rbs
@@ -5,3 +5,11 @@ module Parser
     end
   end
 end
+
+module RuboCop
+  module Cop
+    module ConfigurableEnforcedStyle
+      def no_acceptable_style!: () -> void
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Style/RbsInline/RedundantTypeAnnotation` reported a detected style for every offense, so `--auto-gen-config` wrote an `EnforcedStyle` into `.rubocop_todo.yml` that does not resolve the offenses.

For a redundant trailing return type it reported `:return_type_annotation`, a leftover from the removed `RedundantReturnType` cop that is not in the cop's `SupportedStyles`, so RuboCop refused to even start on the generated config:

```
Error: invalid EnforcedStyle 'return_type_annotation' for
Style/RbsInline/RedundantTypeAnnotation found in .rubocop_todo.yml
Valid choices are: method_type_signature, doc_style, doc_style_and_return_annotation
```

Reporting a supported style is not enough either. Both checks of this cop only fire when two or more annotations describe the same thing (`#:` plus `@rbs` params, or two or more return type sources), so a redundant annotation is an offense under every style — the style only decides which of the annotations is reported. The generated config therefore did not silence the offense:

```ruby
# @rbs return: String
def foo(arg) #: String   # => EnforcedStyle: doc_style_and_return_annotation
end                      # => re-run still reports the `@rbs return`
```

## Changes

- **lib/rubocop/cop/style/rbs_inline/redundant_type_annotation.rb**: Call `no_acceptable_style!` instead of `unexpected_style_detected` in all four `add_offense_for_*` helpers. `--auto-gen-config` then excludes the offending files, which does silence the offenses. This matches `MissingTypeAnnotation`, which also includes `ConfigurableEnforcedStyle` without reporting a detected style.

- **sig/gems/rubocop/rubocop.rbs**: Added a stub for `ConfigurableEnforcedStyle#no_acceptable_style!`, which is missing from the rubocop signatures in gem_rbs_collection.

- **CHANGELOG.md**: Documented the bug fix.

No spec is added. What would be testable at the cop level is `config_to_allow_offenses`, and there is no observable difference between recording `Enabled: false` and recording nothing — `--auto-gen-config` writes the same `Exclude:` list either way — so such a spec would pin the mechanism rather than the behaviour. The behaviour was verified by hand instead (below).

## Verification

Ran `--auto-gen-config` on a sample project before and after the change:

| | before | after |
| --- | --- | --- |
| generated `.rubocop_todo.yml` | `EnforcedStyle: return_type_annotation` | `Exclude: - 'a.rb'` |
| re-run with the generated todo | RuboCop fails to start | no offenses detected |

Also checked the case where the offending files exceed the exclude limit: the todo falls back to `Enabled: false` and the re-run reports no offenses. `bundle exec rake` (rspec, rubocop, steep, rbs:validate) is green.

https://claude.ai/code/session_0187ZW67k5z5XxQ5VR3Ef8E7