### PR TITLE
Fix crash on destructuring arguments in UnmatchedAnnotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **Style/RbsInline**: Added a shared `Mode` setting (`opt_in` / `opt_out`) at the department level to filter which files each cop checks based on the `# rbs_inline: enabled` / `disabled` magic comment.
 - **Style/RbsInline/RequireRbsInlineComment**: Added `Mode` (`opt_in` / `opt_out`) and `AllowMissingComment` options. `AllowMissingComment` lets projects use rbs-inline on only some of their files while keeping the opt-in filter for the rest.
 
+### Bug fixes
+
+- **Style/RbsInline/UnmatchedAnnotations**: Fixed a crash on method definitions taking a destructuring argument (ex. `def foo((a, b))`). The crash also aborted the inspection of the method definition, causing false positives on its valid annotations.
+
 ### Deprecations
 
 - **Style/RbsInline/RequireRbsInlineComment**: `EnforcedStyle` is deprecated in favor of `Mode`. Migrate `always` → `Mode: opt_in`, `never` → `Mode: opt_out`. Will be removed in the next major version.

--- a/lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb
+++ b/lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb
@@ -105,7 +105,9 @@ module RuboCop
               when :forward_arg
                 ["..."]
               else
-                raise
+                # Unnamed parameters (ex. destructuring arguments; `def foo((a, b))`) are not
+                # annotatable because RBS::Inline does not generate types for them.
+                []
               end
             end
           end

--- a/spec/rubocop/cop/style/rbs_inline/unmatched_annotations_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/unmatched_annotations_spec.rb
@@ -96,6 +96,27 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::UnmatchedAnnotations, :config do
     end
   end
 
+  context "when the method definition takes a destructuring argument" do
+    context "when the comment annotates to known arguments" do
+      it "does not register an offense" do
+        expect_no_offenses(<<~RUBY)
+          # @rbs arg: String
+          def method((a, b), arg); end
+        RUBY
+      end
+    end
+
+    context "when the comment annotates to the destructuring argument" do
+      it "registers an offense" do
+        expect_offense(<<~RUBY)
+          # @rbs pair: [Integer, Integer]
+                 ^^^^ Style/RbsInline/UnmatchedAnnotations: target parameter not found.
+          def method((a, b)); end
+        RUBY
+      end
+    end
+  end
+
   context "when an independent annotation comment found" do
     it "registers an offense" do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
## Summary

Fixed a crash in `Style/RbsInline/UnmatchedAnnotations` when analyzing method definitions with destructuring arguments (e.g., `def foo((a, b))`). The crash prevented inspection of valid annotations in such methods, causing false positives.

## Changes

- **lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb**: Modified the `arguments_for` method to return an empty array for unnamed parameters (destructuring arguments) instead of raising an exception. Added a comment explaining that these parameters are not annotatable since RBS::Inline does not generate types for them.

- **spec/rubocop/cop/style/rbs_inline/unmatched_annotations_spec.rb**: Added test coverage for destructuring arguments:
  - Test confirming no offense when annotations target known arguments alongside destructuring
  - Test confirming an offense is registered when trying to annotate the destructuring argument itself

- **CHANGELOG.md**: Documented the bug fix under a new "Bug fixes" section.

## Implementation Details

Destructuring arguments in Ruby (e.g., `def method((a, b))`) are unnamed parameters that cannot be annotated in RBS::Inline. Rather than crashing when encountering them, the cop now gracefully handles them by treating them as non-annotatable, allowing the inspection to continue and properly validate other annotations in the method.

https://claude.ai/code/session_01FZhBBCvyfraf78NQSKNgx9