### PR TITLE
Fix crash when leading comment block lacks trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 - **Style/RbsInline/UnmatchedAnnotations**: Fixed a crash on method definitions taking a destructuring argument (ex. `def foo((a, b))`). The crash also aborted the inspection of the method definition, causing false positives on its valid annotations.
+- **Style/RbsInline/RequireRbsInlineComment**: Fixed a crash (`IndexError`) on a file whose leading comment block ends without a trailing newline. The offense is now reported and the magic comment is inserted on its own line.
 
 ### Deprecations
 

--- a/lib/rubocop/cop/style/rbs_inline/require_rbs_inline_comment.rb
+++ b/lib/rubocop/cop/style/rbs_inline/require_rbs_inline_comment.rb
@@ -106,7 +106,7 @@ module RuboCop
             insert_position = find_insert_position
             add_offense(first_line_range, message: MSG_MISSING) do |corrector|
               insert_range = Parser::Source::Range.new(processed_source.buffer, insert_position, insert_position)
-              corrector.insert_before(insert_range, "# rbs_inline: enabled\n")
+              corrector.insert_before(insert_range, insertion_text(insert_position))
             end
           end
 
@@ -125,7 +125,19 @@ module RuboCop
             return 0 unless first_comment&.source_range&.first_line == 1
 
             last_comment_in_block = find_last_comment_in_first_block
-            last_comment_in_block.source_range.end_pos + 1
+            # `end_pos` points at the newline terminating the comment, so `+ 1` moves past it.
+            # A file without a trailing newline has none, so clamp to the end of the buffer.
+            (last_comment_in_block.source_range.end_pos + 1).clamp(0, processed_source.buffer.source.length)
+          end
+
+          # The insert position lands at the end of the buffer when the file has no trailing
+          # newline. The magic comment then needs its own newline to stay on a separate line.
+          # @rbs insert_position: Integer
+          def insertion_text(insert_position) #: String
+            source = processed_source.buffer.source
+            return "# rbs_inline: enabled\n" if insert_position.zero? || source[insert_position - 1] == "\n"
+
+            "\n# rbs_inline: enabled\n"
           end
 
           def find_last_comment_in_first_block #: Parser::Source::Comment

--- a/sig/rubocop/cop/style/rbs_inline/require_rbs_inline_comment.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/require_rbs_inline_comment.rbs
@@ -83,6 +83,11 @@ module RuboCop
 
           def find_insert_position: () -> Integer
 
+          # The insert position lands at the end of the buffer when the file has no trailing
+          # newline. The magic comment then needs its own newline to stay on a separate line.
+          # @rbs insert_position: Integer
+          def insertion_text: (Integer insert_position) -> String
+
           def find_last_comment_in_first_block: () -> Parser::Source::Comment
 
           def effective_mode: () -> FileFilter::mode

--- a/spec/rubocop/cop/style/rbs_inline/require_rbs_inline_comment_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/require_rbs_inline_comment_spec.rb
@@ -92,6 +92,22 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::RequireRbsInlineComment, :config 
         end
       end
 
+      context "when the leading comment block ends without a trailing newline" do
+        it "registers an offense and inserts the magic comment on its own line" do
+          expect_offense(<<~RUBY.chomp)
+            # frozen_string_literal: true
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Missing `# rbs_inline:` magic comment.
+            # encoding: utf-8
+          RUBY
+
+          expect_correction(<<~RUBY)
+            # frozen_string_literal: true
+            # encoding: utf-8
+            # rbs_inline: enabled
+          RUBY
+        end
+      end
+
       context "when the pragma has extra spaces (malformed)" do
         it "does not accept the malformed pragma and registers an offense" do
           expect_offense(<<~RUBY)


### PR DESCRIPTION
## Summary

Fixes an `IndexError` crash in `Style/RbsInline/RequireRbsInlineComment` when processing a file whose leading comment block ends without a trailing newline. The cop now correctly reports the offense and inserts the magic comment on its own line.

## Changes

- **`find_insert_position`**: Added `clamp` to prevent the insert position from exceeding the buffer length when a file lacks a trailing newline.
- **`insertion_text` (new method)**: Determines the appropriate text to insert based on whether the insert position is at the start of the file or immediately after a newline. If neither condition is met, prepends a newline to keep the magic comment on its own line.
- **Test coverage**: Added a spec case verifying the crash is fixed and the magic comment is inserted correctly on its own line.
- **Type signature**: Added RBS signature for the new `insertion_text` method.
- **CHANGELOG**: Documented the bug fix.

## Implementation Details

The root cause was that `end_pos + 1` could point past the end of the buffer when the file had no trailing newline, causing an `IndexError` when used as an insertion point. The fix clamps the position to the buffer bounds and then determines whether a leading newline is needed based on the character immediately before the insertion point.

https://claude.ai/code/session_01DH6Sqja11f4pBUCbPCRkXg