### PR TITLE
Remove broad rescue from SourceCodeHelper#character_offset

### DIFF
--- a/lib/rubocop/cop/style/rbs_inline/mixin/source_code_helper.rb
+++ b/lib/rubocop/cop/style/rbs_inline/mixin/source_code_helper.rb
@@ -12,11 +12,9 @@ module RuboCop
           # Convert byte offset to character offset
           # @rbs byte_offset: Integer
           def character_offset(byte_offset) #: Integer
-            source = processed_source.buffer.source.dup.force_encoding("ASCII")
-            text = source[...byte_offset] or raise
-            text.force_encoding(processed_source.buffer.source.encoding).size
-          rescue StandardError
-            byte_offset
+            source = processed_source.buffer.source
+            prefix = source.byteslice(0, byte_offset) or raise
+            prefix.size
           end
 
           # @rbs pos: Integer

--- a/spec/rubocop/cop/style/rbs_inline/mixin/source_code_helper_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/mixin/source_code_helper_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# These specs exercise the shared `SourceCodeHelper` mixin through a bare host
+# class, since the offset conversion it provides is independent of any cop.
+RSpec.describe RuboCop::Cop::Style::RbsInline::SourceCodeHelper do
+  let(:helper_class) do
+    Class.new do
+      include RuboCop::Cop::Style::RbsInline::SourceCodeHelper
+
+      attr_reader :processed_source
+
+      def initialize(processed_source)
+        @processed_source = processed_source
+      end
+    end
+  end
+  let(:helper) { helper_class.new(parse_source(source, "example.rb")) }
+
+  describe "#character_offset" do
+    subject { helper.character_offset(byte_offset) }
+
+    context "when the source is ASCII only" do
+      let(:source) { "# @rbs foo: String\n" }
+      let(:byte_offset) { 7 }
+
+      it { is_expected.to eq(7) }
+    end
+
+    context "when the leading bytes contain multibyte characters" do
+      # `"# コメント\n"` is 15 bytes but only 7 characters.
+      let(:source) { "# コメント\n# @rbs foo: String\n" }
+      let(:byte_offset) { 15 }
+
+      it "counts characters rather than bytes" do
+        expect(subject).to eq(7)
+      end
+    end
+  end
+
+  describe "#location_to_range" do
+    subject { helper.location_to_range(location) }
+
+    let(:location) { Prism.parse(source).value.statements.body.first.location }
+
+    context "when the source contains multibyte characters before the node" do
+      let(:source) { <<~RUBY }
+        # コメント
+        foo
+      RUBY
+
+      it "returns a range that points at the node" do
+        expect(subject.source).to eq("foo")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`SourceCodeHelper#character_offset` rescued `StandardError` and fell back to returning the byte offset as if it were a character offset. Any unexpected error was swallowed and the cop kept going, reporting an offense at a misplaced range instead of surfacing the bug.

## Changes

- **Dropped the broad `rescue StandardError`.** Unexpected errors now surface as RuboCop errors rather than silently producing a misaligned offense.
- **Replaced the encoding round-trip with `String#byteslice`.** The old code duplicated the source, forced it to US-ASCII to make `[]` index by bytes, sliced, then forced the encoding back. `byteslice` slices by bytes directly, so the intent no longer depends on US-ASCII indexing happening to coincide with byte indexing.
- The `or raise` guard stays, since `byteslice` is typed as returning `String?` and only a negative length can produce that nil. That matches how the codebase narrows other unreachable branches (e.g. `unmatched_annotations.rb`).

## Added test cases

`spec/rubocop/cop/style/rbs_inline/mixin/source_code_helper_spec.rb`

- `#character_offset`
  - when the source is ASCII only — the offset is returned unchanged
  - when the leading bytes contain multibyte characters — characters are counted rather than bytes (15 bytes → 7 characters)
- `#location_to_range`
  - when the source contains multibyte characters before the node — the range still points at the node

https://claude.ai/code/session_01Mv1x9rjLE9nVuDUYif5Aks