### PR TITLE
Stop mutating parsed_comments in UnmatchedAnnotations

### DIFF
--- a/lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb
+++ b/lib/rubocop/cop/style/rbs_inline/unmatched_annotations.rb
@@ -25,8 +25,11 @@ module RuboCop
 
           MSG = "target parameter not found."
 
+          attr_reader :processed_comments #: Set[RBS::Inline::AnnotationParser::ParsingResult] -- matched to a def node
+
           def on_new_investigation #: void
             super
+            @processed_comments = Set.new
             parse_comments
           end
 
@@ -42,6 +45,8 @@ module RuboCop
 
           def on_investigation_end #: void
             parsed_comments.each do |comment|
+              next if processed?(comment)
+
               comment.each_annotation do |annotation|
                 case annotation
                 when RBS::Inline::AST::Annotations::BlockType,
@@ -58,15 +63,13 @@ module RuboCop
           private
 
           # @rbs node: RuboCop::AST::DefNode
-          def process(node) #: void # rubocop:disable Metrics/CyclomaticComplexity
+          def process(node) #: void
             arguments = arguments_for(node)
 
-            comment = parsed_comments.find do |r|
-              r.comments.map(&:location).map(&:start_line).include?(node.location.line - 1)
-            end
+            comment = leading_comment_for(node)
             return unless comment
 
-            parsed_comments.delete(comment)
+            mark_processed(comment)
             comment.each_annotation do |annotation|
               case annotation
               when RBS::Inline::AST::Annotations::IvarType
@@ -75,6 +78,25 @@ module RuboCop
                 add_offense_for(annotation) unless arguments.include?(annotation_name(annotation))
               end
             end
+          end
+
+          # @rbs node: RuboCop::AST::DefNode
+          def leading_comment_for(node) #: RBS::Inline::AnnotationParser::ParsingResult?
+            parsed_comments.find do |comment|
+              next if processed?(comment)
+
+              comment.comments.map(&:location).map(&:start_line).include?(node.location.line - 1)
+            end
+          end
+
+          # @rbs comment: RBS::Inline::AnnotationParser::ParsingResult
+          def mark_processed(comment) #: void
+            processed_comments << comment
+          end
+
+          # @rbs comment: RBS::Inline::AnnotationParser::ParsingResult
+          def processed?(comment) #: bool
+            processed_comments.include?(comment)
           end
 
           # @rbs node: RuboCop::AST::DefNode

--- a/sig/rubocop/cop/style/rbs_inline/unmatched_annotations.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/unmatched_annotations.rbs
@@ -25,6 +25,8 @@ module RuboCop
 
           MSG: ::String
 
+          attr_reader processed_comments: Set[RBS::Inline::AnnotationParser::ParsingResult]
+
           def on_new_investigation: () -> void
 
           # @rbs node: RuboCop::AST::DefNode
@@ -39,6 +41,15 @@ module RuboCop
 
           # @rbs node: RuboCop::AST::DefNode
           def process: (RuboCop::AST::DefNode node) -> void
+
+          # @rbs node: RuboCop::AST::DefNode
+          def leading_comment_for: (RuboCop::AST::DefNode node) -> RBS::Inline::AnnotationParser::ParsingResult?
+
+          # @rbs comment: RBS::Inline::AnnotationParser::ParsingResult
+          def mark_processed: (RBS::Inline::AnnotationParser::ParsingResult comment) -> void
+
+          # @rbs comment: RBS::Inline::AnnotationParser::ParsingResult
+          def processed?: (RBS::Inline::AnnotationParser::ParsingResult comment) -> bool
 
           # @rbs node: RuboCop::AST::DefNode
           def arguments_for: (RuboCop::AST::DefNode node) -> Array[String]


### PR DESCRIPTION
## Summary

`UnmatchedAnnotations#process` removed each matched comment from `parsed_comments`, using the memoized array from `CommentParser` as a consumption queue, and `on_investigation_end` reported whatever was left over as annotations with no method definition.

Behavior is correct today, but the cop mutates state it shares with every other `CommentParser` helper. The moment this cop also calls one of them (`find_leading_annotation` and friends all scan `parsed_comments`), those helpers see an array that shrinks as definitions are visited. This replaces the mutation with separate tracking, so the shared collection stays intact.

## Changes

- Track consumed comments in a `processed_comments` `Set`, exposed via `attr_reader` (matching `MethodCommentSpacing`, which keeps the same kind of set) and initialized in `on_new_investigation`
- Replace `parsed_comments.delete(comment)` with `mark_processed` / `processed?`
- Extract the leading-comment lookup into `leading_comment_for`, which skips already-processed comments
- Skip processed comments in the `on_investigation_end` loop
- Drop the now-unneeded `# rubocop:disable Metrics/CyclomaticComplexity` on `process`

No behavior change, so the existing specs cover the refactoring and no test cases were added.

https://claude.ai/code/session_01S5fCtBafcgW7EWZGA9XWiy