### PR TITLE
Bump version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.8.0 (2026-07-26)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 - **Style/RbsInline**: Added a shared `Mode` setting (`opt_in` / `opt_out`) at the department level to filter which files each cop checks based on the `# rbs_inline: enabled` / `disabled` magic comment.
 - **Style/RbsInline/RequireRbsInlineComment**: Added the `AllowMissingComment` option, which lets projects use rbs-inline on only some of their files while keeping the opt-in filter for the rest.
 
-### Bug fixes
+### Bug Fixes
 
+- **Style/RbsInline/DataClassCommentAlignment**, **Style/RbsInline/StructClassCommentAlignment**: Fixed the expected annotation column being derived from arguments that cannot carry an annotation (a splat, or for `Struct.new` a leading struct name or `keyword_init:`), which reported false positives on already aligned code and made autocorrect over-pad the annotations.
+- **Style/RbsInline/MissingDataClassAnnotation**, **Style/RbsInline/MissingStructClassAnnotation**: Fixed autocorrect padding the inserted annotations to the width of an argument that cannot carry one (a splat, or for `Struct.new` a leading struct name or `keyword_init:`).
 - **Style/RbsInline/UnmatchedAnnotations**: Fixed a crash on method definitions taking a destructuring argument (ex. `def foo((a, b))`). The crash also aborted the inspection of the method definition, causing false positives on its valid annotations.
 - **Style/RbsInline/RequireRbsInlineComment**: Fixed a crash (`IndexError`) on a file whose leading comment block ends without a trailing newline. The offense is now reported and the magic comment is inserted on its own line.
 - **Style/RbsInline/RedundantTypeAnnotation**: Fixed `--auto-gen-config` generating an `EnforcedStyle` that does not resolve the offenses (including the unsupported `return_type_annotation`, which made RuboCop fail to start on the generated `.rubocop_todo.yml`). No style can make redundant annotations offense-free, so the offending files are now excluded instead.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-rbs_inline (1.7.0)
+    rubocop-rbs_inline (1.8.0)
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)

--- a/lib/rubocop/rbs_inline/version.rb
+++ b/lib/rubocop/rbs_inline/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module RbsInline
-    VERSION = "1.7.0"
+    VERSION = "1.8.0"
   end
 end


### PR DESCRIPTION
Cuts the 1.8.0 release.

A minor bump: this cycle adds the department-level `Mode` setting and the `RequireRbsInlineComment` `AllowMissingComment` option, with no breaking change. `EnforcedStyle` is only deprecated, not removed, and both new options default to the previous behavior (`Mode: ~`, `AllowMissingComment: false`).

## Commits

- **Add missing changelog entries for struct annotation alignment fix** — the fix in e2fb4ff landed without a changelog entry. It is recorded here split by symptom: the alignment cops reported false positives on already aligned code, while the missing-annotation cops only over-padded on autocorrect. Also aligns the section heading with the `Bug Fixes` casing used by every other release.
- **Bump version to 1.8.0** — `## Unreleased` → `## 1.8.0 (2026-07-26)`, plus the `VERSION` constant and `Gemfile.lock`.

## Release contents

### Enhancements

- **Style/RbsInline**: shared `Mode` setting (`opt_in` / `opt_out`) at the department level.
- **Style/RbsInline/RequireRbsInlineComment**: `AllowMissingComment` option.

### Bug Fixes

- **DataClassCommentAlignment**, **StructClassCommentAlignment**: expected annotation column no longer derived from arguments that cannot carry an annotation.
- **MissingDataClassAnnotation**, **MissingStructClassAnnotation**: autocorrect no longer pads to the width of such an argument.
- **UnmatchedAnnotations**: crash on destructuring arguments (`def foo((a, b))`).
- **RequireRbsInlineComment**: `IndexError` on a leading comment block without a trailing newline.
- **RedundantTypeAnnotation**: `--auto-gen-config` generating an unusable `EnforcedStyle`.

### Deprecations

- **RequireRbsInlineComment**: `EnforcedStyle` in favor of the department-level `Mode`.

## Verification

`bundle exec rake` is green on the branch — 62 files inspected / no offenses, 439 examples / 0 failures, no Steep type errors, `rbs validate` clean.

Note that merging this fires `.github/workflows/release.yml` (it triggers on a `lib/rubocop/rbs_inline/version.rb` change pushed to `main`), so the merge publishes 1.8.0 to RubyGems.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvgJFqgjPjDWtBY1DegKV1)_