### PR TITLE
Make Mode an official setting and drop the deprecated EnforcedStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- **Style/RbsInline**: `Mode` now defaults to `opt_in`, and any value other than `opt_in` / `opt_out` fails the run.
+- **Style/RbsInline/RequireRbsInlineComment**: Removed the deprecated `EnforcedStyle`. Use `Style/RbsInline: Mode` instead: `always` → `opt_in`, `never` → `opt_out`.
+
 ## 1.8.0 (2026-07-26)
 
 ### Enhancements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Cops live in `lib/rubocop/cop/style/rbs_inline/`, one per file; the shared modul
 
 Conventions:
 
-- Every cop `prepend`s `FileFilter` except `RequireRbsInlineComment`.
+- Every cop `prepend`s `FileFilter` except `RequireRbsInlineComment`, which reads `Mode` through `ModeConfig` instead — it has to run on the files the filter skips.
 - `Data.define` and `Struct.new` cops come in pairs sharing a base module. Behavior belongs in the module; only the node matcher and `MSG` in the cop.
 
 ### Plugin System
@@ -54,6 +54,8 @@ The gem integrates with RuboCop via LintRoller (`lib/rubocop/rbs_inline/plugin.r
 Tests use RuboCop's RSpec support helpers (`expect_offense` / `expect_no_offenses`). Test files mirror the cop file structure under `spec/rubocop/cop/style/rbs_inline/`.
 
 `:config` specs build a bare `RuboCop::Config`, so `config/default.yml` and RuboCop's department-to-cop defaults are not merged in. A spec that sets a value at the department level proves nothing about how it resolves in a real run.
+
+The department-level `Mode` is not merged in either, and the cops have no default for it, so `spec_helper.rb` declares `Mode: opt_out` for every `:config` spec, and `rbs_inline_config` for the specs written against the default configuration. A spec that builds its own config has to declare it itself.
 
 ## Code Style Notes
 

--- a/README.md
+++ b/README.md
@@ -31,18 +31,17 @@ rubocop-rbs_inline provides the following cops to validate [RBS::Inline](https:/
 
 The `Style/RbsInline` department has a shared `Mode` setting that gates whether each `Style/RbsInline/*` cop reports offenses on a given file:
 
-- `Mode: opt_in` — cops only check files that carry `# rbs_inline: enabled`. Files with `# rbs_inline: disabled` or no magic comment are skipped. Matches RBS::Inline's opt-in mode.
+- `Mode: opt_in` (default) — cops only check files that carry `# rbs_inline: enabled`. Files with `# rbs_inline: disabled` or no magic comment are skipped. Matches RBS::Inline's opt-in mode.
 - `Mode: opt_out` — cops check every file except those with `# rbs_inline: disabled`. Matches RBS::Inline's opt-out mode.
-- unset — cops check every file (legacy behavior; the default will change to `opt_in` in the next major release).
 
 Declare it once at the department level in your `.rubocop.yml`:
 
 ```yaml
 Style/RbsInline:
-  Mode: opt_in
+  Mode: opt_out
 ```
 
-Unknown `Mode` values (e.g. `Mode: opt-in`) emit a warning and disable filtering for the run.
+Any other value (e.g. `Mode: opt-in`) fails the run with a configuration error.
 
 ### Style/RbsInline/DataClassCommentAlignment
 
@@ -504,8 +503,6 @@ Style/RbsInline/RequireRbsInlineComment:
   AllowMissingComment: true
 ```
 
-The legacy `EnforcedStyle` parameter (`always` / `never`) is deprecated in favor of `Mode`; it will be removed in the next major release.
-
 **Examples (Mode: opt_in):**
 ```ruby
 # bad
@@ -659,7 +656,7 @@ Style/RbsInline/MissingTypeAnnotation:
   Visibility: public
 ```
 
-To restrict every cop to files that carry `# rbs_inline: enabled`, see [Style/RbsInline (shared configuration)](#stylerbsinline-shared-configuration).
+To check every file rather than only those that carry `# rbs_inline: enabled`, see [Style/RbsInline (shared configuration)](#stylerbsinline-shared-configuration).
 
 See [config/default.yml](config/default.yml) for all available configuration options.
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,7 +5,7 @@ Style/RbsInline:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
-  Mode: ~
+  Mode: opt_in
 
 Style/RbsInline/DataClassCommentAlignment:
   Description: "Checks that `#:` inline type annotations in `Data.define` blocks are aligned."
@@ -96,7 +96,6 @@ Style/RbsInline/RequireRbsInlineComment:
   Enabled: true
   VersionAdded: "1.5.0"
   AllowMissingComment: false
-  EnforcedStyle: ~
 
 Style/RbsInline/StructClassCommentAlignment:
   Description: "Checks that `#:` inline type annotations in `Struct.new` blocks are aligned."

--- a/lib/rubocop/cop/rbs_inline_cops.rb
+++ b/lib/rubocop/cop/rbs_inline_cops.rb
@@ -11,6 +11,7 @@ require_relative "style/rbs_inline/mixin/data_struct_helper"
 require_relative "style/rbs_inline/mixin/missing_class_annotation"
 require_relative "style/rbs_inline/mixin/class_comment_alignment"
 require_relative "style/rbs_inline/mixin/data_class_matcher"
+require_relative "style/rbs_inline/mixin/mode_config"
 require_relative "style/rbs_inline/mixin/file_filter"
 require_relative "style/rbs_inline/mixin/struct_class_matcher"
 

--- a/lib/rubocop/cop/style/rbs_inline/mixin/file_filter.rb
+++ b/lib/rubocop/cop/style/rbs_inline/mixin/file_filter.rb
@@ -8,8 +8,7 @@ module RuboCop
         #
         # When `Mode` is `opt_in`, offenses are only reported for files that contain
         # a `# rbs_inline: enabled` magic comment. When `Mode` is `opt_out`, all files
-        # are checked unless they contain `# rbs_inline: disabled`. When `Mode` is not
-        # set, all files are checked (legacy behavior).
+        # are checked unless they contain `# rbs_inline: disabled`.
         #
         # This module is designed to be `prepend`ed to a cop so that it can short-circuit
         # the cop's heavy work (annotation parsing via `parse_comments`) and suppress any
@@ -17,31 +16,10 @@ module RuboCop
         #
         # @rbs module-self RuboCop::Cop::Base
         module FileFilter
-          # @rbs! type mode = :opt_in | :opt_out
+          include ModeConfig
 
           MAGIC_COMMENT_ENABLED  = /\A# rbs_inline: enabled\R?\z/ #: Regexp
           MAGIC_COMMENT_DISABLED = /\A# rbs_inline: disabled\R?\z/ #: Regexp
-
-          SUPPORTED_MODES = %i[opt_in opt_out].freeze #: Array[mode]
-
-          # Tracks Mode values that have already been reported as invalid, so we
-          # only emit one warning per typo across the whole rubocop run instead of
-          # one per (file × cop).
-          # @rbs self.@warned_invalid_modes: Hash[String, bool]
-
-          @warned_invalid_modes = {} # rubocop:disable Style/RbsInline/UntypedInstanceVariable
-
-          # @rbs raw: untyped
-          def self.warn_invalid_mode(raw) #: void
-            key = raw.to_s
-            return if @warned_invalid_modes[key]
-
-            @warned_invalid_modes[key] = true
-            Kernel.warn(
-              "[rubocop-rbs_inline] Style/RbsInline Mode #{raw.inspect} is not supported. " \
-              "Expected one of: #{SUPPORTED_MODES.join(", ")}. Filtering is disabled for this run."
-            )
-          end
 
           # @rbs @rbs_inline_skip_file: bool
 
@@ -68,28 +46,12 @@ module RuboCop
           private
 
           def skip_by_mode? #: bool
-            mode = configured_mode
-            return false if mode.nil?
-
             # `# rbs_inline: disabled` always opts a file out, regardless of Mode
             # (matches rbs-inline itself: rbs-inline skips disabled files in both
             # opt_in and opt_out modes).
             return true if rbs_inline_disabled?
 
-            mode == :opt_in && !rbs_inline_enabled?
-          end
-
-          def configured_mode #: mode?
-            raw = cop_config["Mode"]
-            return nil if raw.nil?
-
-            # `raw.to_s.to_sym` handles YAML-native Integer / Boolean without
-            # raising NoMethodError on the plain `to_sym`.
-            mode = raw.to_s.to_sym
-            return mode if SUPPORTED_MODES.include?(mode)
-
-            FileFilter.warn_invalid_mode(raw)
-            nil
+            configured_mode == :opt_in && !rbs_inline_enabled?
           end
 
           # Iterate the already-materialized `processed_source.comments` so this

--- a/lib/rubocop/cop/style/rbs_inline/mixin/mode_config.rb
+++ b/lib/rubocop/cop/style/rbs_inline/mixin/mode_config.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      module RbsInline
+        # Resolves the `Mode` setting shared by every cop in the `Style/RbsInline`
+        # department.
+        #
+        # @rbs module-self RuboCop::Cop::Base
+        module ModeConfig
+          # @rbs! type mode = :opt_in | :opt_out
+
+          SUPPORTED_MODES = %i[opt_in opt_out].freeze #: Array[mode]
+
+          # Hook RuboCop calls while mobilizing its cops, so an unsupported `Mode`
+          # fails the run as a config error instead of an error on every file.
+          def validate_config #: void
+            configured_mode
+          end
+
+          private
+
+          def configured_mode #: mode
+            raw = cop_config["Mode"]
+            # `raw.to_s.to_sym` handles YAML-native Integer / Boolean without
+            # raising NoMethodError on the plain `to_sym`.
+            mode = raw.to_s.to_sym
+            return mode if SUPPORTED_MODES.include?(mode)
+
+            raise ValidationError,
+                  "`Style/RbsInline: Mode: #{raw.inspect}` is not supported. " \
+                  "Expected one of: #{SUPPORTED_MODES.join(", ")}."
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/style/rbs_inline/require_rbs_inline_comment.rb
+++ b/lib/rubocop/cop/style/rbs_inline/require_rbs_inline_comment.rb
@@ -53,33 +53,20 @@ module RuboCop
         #   end
         #
         class RequireRbsInlineComment < Base
+          include ModeConfig
           include RangeHelp
           extend AutoCorrector
 
           MSG_MISSING = "Missing `# rbs_inline:` magic comment."
           MSG_FORBIDDEN = "Remove `# rbs_inline:` magic comment."
 
-          # @rbs self.@enforced_style_deprecation_warned: bool
-
-          @enforced_style_deprecation_warned = false # rubocop:disable Style/RbsInline/UntypedInstanceVariable
-
-          def self.enforced_style_deprecation_warned? #: bool
-            @enforced_style_deprecation_warned == true
-          end
-
-          def self.mark_enforced_style_deprecation_warned! #: void
-            @enforced_style_deprecation_warned = true
-          end
-
           def on_new_investigation #: void
             return if processed_source.buffer.source.empty?
-
-            warn_deprecated_enforced_style
 
             magic_comment = find_rbs_inline_magic_comment
             return if disabled?(magic_comment)
 
-            case effective_mode
+            case configured_mode
             when :opt_in then check_opt_in(magic_comment)
             when :opt_out then check_opt_out(magic_comment)
             end
@@ -154,34 +141,8 @@ module RuboCop
             comments[last_idx] || raise
           end
 
-          def effective_mode #: FileFilter::mode
-            mode = cop_config["Mode"]
-            if mode
-              # `raw.to_s.to_sym` handles YAML-native Integer / Boolean safely.
-              sym = mode.to_s.to_sym
-              return sym if FileFilter::SUPPORTED_MODES.include?(sym)
-
-              FileFilter.warn_invalid_mode(mode)
-            end
-
-            cop_config["EnforcedStyle"]&.to_sym == :never ? :opt_out : :opt_in
-          end
-
           def allow_missing_comment? #: bool
             cop_config["AllowMissingComment"] == true
-          end
-
-          def warn_deprecated_enforced_style #: void
-            return if self.class.enforced_style_deprecation_warned?
-            return if cop_config["EnforcedStyle"].nil?
-
-            self.class.mark_enforced_style_deprecation_warned!
-            Kernel.warn(
-              "[rubocop-rbs_inline] Style/RbsInline/RequireRbsInlineComment.EnforcedStyle is deprecated. " \
-              "Please migrate to `Style/RbsInline: Mode: opt_in` (was `EnforcedStyle: always`) or " \
-              "`Style/RbsInline: Mode: opt_out` (was `EnforcedStyle: never`). " \
-              "EnforcedStyle will be removed in the next major version."
-            )
           end
 
           def first_line_range #: Parser::Source::Range

--- a/sig/gems/rubocop/rubocop.rbs
+++ b/sig/gems/rubocop/rubocop.rbs
@@ -7,6 +7,12 @@ module Parser
 end
 
 module RuboCop
+  class Error < StandardError
+  end
+
+  class ValidationError < Error
+  end
+
   module Cop
     module ConfigurableEnforcedStyle
       def no_acceptable_style!: () -> void

--- a/sig/rubocop/cop/style/rbs_inline/mixin/file_filter.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/mixin/file_filter.rbs
@@ -8,8 +8,7 @@ module RuboCop
         #
         # When `Mode` is `opt_in`, offenses are only reported for files that contain
         # a `# rbs_inline: enabled` magic comment. When `Mode` is `opt_out`, all files
-        # are checked unless they contain `# rbs_inline: disabled`. When `Mode` is not
-        # set, all files are checked (legacy behavior).
+        # are checked unless they contain `# rbs_inline: disabled`.
         #
         # This module is designed to be `prepend`ed to a cop so that it can short-circuit
         # the cop's heavy work (annotation parsing via `parse_comments`) and suppress any
@@ -17,18 +16,11 @@ module RuboCop
         #
         # @rbs module-self RuboCop::Cop::Base
         module FileFilter : RuboCop::Cop::Base
-          type mode = :opt_in | :opt_out
+          include ModeConfig
 
           MAGIC_COMMENT_ENABLED: Regexp
 
           MAGIC_COMMENT_DISABLED: Regexp
-
-          SUPPORTED_MODES: Array[mode]
-
-          self.@warned_invalid_modes: Hash[String, bool]
-
-          # @rbs raw: untyped
-          def self.warn_invalid_mode: (untyped raw) -> void
 
           @rbs_inline_skip_file: bool
 
@@ -46,8 +38,6 @@ module RuboCop
           private
 
           def skip_by_mode?: () -> bool
-
-          def configured_mode: () -> mode?
 
           # Iterate the already-materialized `processed_source.comments` so this
           # matches RequireRbsInlineComment's detection exactly (line endings,

--- a/sig/rubocop/cop/style/rbs_inline/mixin/mode_config.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/mixin/mode_config.rbs
@@ -1,0 +1,27 @@
+# Generated from lib/rubocop/cop/style/rbs_inline/mixin/mode_config.rb with RBS::Inline
+
+module RuboCop
+  module Cop
+    module Style
+      module RbsInline
+        # Resolves the `Mode` setting shared by every cop in the `Style/RbsInline`
+        # department.
+        #
+        # @rbs module-self RuboCop::Cop::Base
+        module ModeConfig : RuboCop::Cop::Base
+          type mode = :opt_in | :opt_out
+
+          SUPPORTED_MODES: Array[mode]
+
+          # Hook RuboCop calls while mobilizing its cops, so an unsupported `Mode`
+          # fails the run as a config error instead of an error on every file.
+          def validate_config: () -> void
+
+          private
+
+          def configured_mode: () -> mode
+        end
+      end
+    end
+  end
+end

--- a/sig/rubocop/cop/style/rbs_inline/require_rbs_inline_comment.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/require_rbs_inline_comment.rbs
@@ -52,6 +52,8 @@ module RuboCop
         #   class Foo
         #   end
         class RequireRbsInlineComment < Base
+          include ModeConfig
+
           include RangeHelp
 
           extend AutoCorrector
@@ -59,12 +61,6 @@ module RuboCop
           MSG_MISSING: ::String
 
           MSG_FORBIDDEN: ::String
-
-          self.@enforced_style_deprecation_warned: bool
-
-          def self.enforced_style_deprecation_warned?: () -> bool
-
-          def self.mark_enforced_style_deprecation_warned!: () -> void
 
           def on_new_investigation: () -> void
 
@@ -90,11 +86,7 @@ module RuboCop
 
           def find_last_comment_in_first_block: () -> Parser::Source::Comment
 
-          def effective_mode: () -> FileFilter::mode
-
           def allow_missing_comment?: () -> bool
-
-          def warn_deprecated_enforced_style: () -> void
 
           def first_line_range: () -> Parser::Source::Range
         end

--- a/spec/rubocop/cop/style/rbs_inline/data_class_comment_alignment_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/data_class_comment_alignment_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::DataClassCommentAlignment, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when an annotation is too close" do
     it "registers an offense and corrects it" do

--- a/spec/rubocop/cop/style/rbs_inline/data_define_with_block_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/data_define_with_block_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::DataDefineWithBlock, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when Data.define is called with a do...end block" do
     it "registers an offense" do

--- a/spec/rubocop/cop/style/rbs_inline/embedded_rbs_spacing_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/embedded_rbs_spacing_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::EmbeddedRbsSpacing, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when @rbs! comment is directly followed by code" do
     it "registers an offense" do

--- a/spec/rubocop/cop/style/rbs_inline/invalid_comment_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/invalid_comment_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::InvalidComment, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when code contains `#:` style annotation comments" do
     context "when using invalid annotation comments" do

--- a/spec/rubocop/cop/style/rbs_inline/invalid_types_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/invalid_types_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::InvalidTypes, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when using `#bad_method`" do
     it "registers an offense" do

--- a/spec/rubocop/cop/style/rbs_inline/keyword_separator_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/keyword_separator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::KeywordSeparator, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when using `:` after keyword outside a method definition" do
     it "registers an offense" do

--- a/spec/rubocop/cop/style/rbs_inline/method_comment_spacing_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/method_comment_spacing_spec.rb
@@ -2,7 +2,10 @@
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::MethodCommentSpacing, :config do
   let(:config) do
-    RuboCop::Config.new("Style/RbsInline/MethodCommentSpacing" => { "Enabled" => true })
+    RuboCop::Config.new(
+      "Style/RbsInline" => { "Mode" => "opt_out" },
+      "Style/RbsInline/MethodCommentSpacing" => { "Enabled" => true }
+    )
   end
 
   context "when method annotation has blank line before method definition" do

--- a/spec/rubocop/cop/style/rbs_inline/missing_data_class_annotation_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/missing_data_class_annotation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::MissingDataClassAnnotation, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when each attribute is missing an inline type annotation" do
     it "registers an offense and corrects each attribute" do

--- a/spec/rubocop/cop/style/rbs_inline/missing_struct_class_annotation_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/missing_struct_class_annotation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::MissingStructClassAnnotation, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "with attributes missing inline type annotations" do
     it "registers an offense and corrects each attribute" do

--- a/spec/rubocop/cop/style/rbs_inline/missing_type_annotation_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/missing_type_annotation_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::MissingTypeAnnotation, :config do
   context "when EnforcedStyle is method_type_signature" do
     let(:config) do
       RuboCop::Config.new(
+        "Style/RbsInline" => { "Mode" => "opt_out" },
         "Style/RbsInline/MissingTypeAnnotation" => {
           "EnforcedStyle" => "method_type_signature",
           "SupportedStyles" => %w[method_type_signature doc_style doc_style_and_return_annotation],
@@ -185,6 +186,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::MissingTypeAnnotation, :config do
   context "when EnforcedStyle is doc_style" do
     let(:config) do
       RuboCop::Config.new(
+        "Style/RbsInline" => { "Mode" => "opt_out" },
         "Style/RbsInline/MissingTypeAnnotation" => {
           "EnforcedStyle" => "doc_style",
           "SupportedStyles" => %w[method_type_signature doc_style doc_style_and_return_annotation],
@@ -486,6 +488,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::MissingTypeAnnotation, :config do
   context "when EnforcedStyle is doc_style_and_return_annotation" do
     let(:config) do
       RuboCop::Config.new(
+        "Style/RbsInline" => { "Mode" => "opt_out" },
         "Style/RbsInline/MissingTypeAnnotation" => {
           "EnforcedStyle" => "doc_style_and_return_annotation",
           "SupportedStyles" => %w[method_type_signature doc_style doc_style_and_return_annotation],
@@ -816,6 +819,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::MissingTypeAnnotation, :config do
   context "when EnforcedStyle is method_type_signature_or_return_annotation" do
     let(:config) do
       RuboCop::Config.new(
+        "Style/RbsInline" => { "Mode" => "opt_out" },
         "Style/RbsInline/MissingTypeAnnotation" => {
           "EnforcedStyle" => "method_type_signature_or_return_annotation",
           "SupportedStyles" => %w[method_type_signature doc_style doc_style_and_return_annotation
@@ -1013,6 +1017,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::MissingTypeAnnotation, :config do
   context "when Visibility is public" do
     let(:config) do
       RuboCop::Config.new(
+        "Style/RbsInline" => { "Mode" => "opt_out" },
         "Style/RbsInline/MissingTypeAnnotation" => {
           "EnforcedStyle" => "method_type_signature",
           "SupportedStyles" => %w[method_type_signature doc_style doc_style_and_return_annotation],
@@ -1165,6 +1170,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::MissingTypeAnnotation, :config do
   context "when Visibility is all" do
     let(:config) do
       RuboCop::Config.new(
+        "Style/RbsInline" => { "Mode" => "opt_out" },
         "Style/RbsInline/MissingTypeAnnotation" => {
           "EnforcedStyle" => "method_type_signature",
           "SupportedStyles" => %w[method_type_signature doc_style doc_style_and_return_annotation],

--- a/spec/rubocop/cop/style/rbs_inline/mixin/file_filter_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/mixin/file_filter_spec.rb
@@ -8,28 +8,6 @@
 RSpec.describe RuboCop::Cop::Style::RbsInline::FileFilter, :config do
   let(:cop_class) { RuboCop::Cop::Style::RbsInline::InvalidComment }
 
-  before do
-    described_class.instance_variable_set(:@warned_invalid_modes, {})
-    allow(Kernel).to receive(:warn)
-  end
-
-  shared_examples "runs on the file" do
-    it "reports offenses in the file" do
-      expect_offense(<<~RUBY)
-        # () -> void
-        ^^^^^^^^^^^^ Invalid RBS annotation comment found.
-      RUBY
-    end
-  end
-
-  shared_examples "skips the file" do
-    it "does not report offenses in the file" do
-      expect_no_offenses(<<~RUBY)
-        # () -> void
-      RUBY
-    end
-  end
-
   context "when Mode is opt_in" do
     let(:config) { RuboCop::Config.new("Style/RbsInline" => { "Mode" => "opt_in" }) }
 
@@ -53,7 +31,11 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::FileFilter, :config do
     end
 
     context "when the file has no magic comment" do
-      it_behaves_like "skips the file"
+      it "skips the file" do
+        expect_no_offenses(<<~RUBY)
+          # () -> void
+        RUBY
+      end
     end
 
     context "when the pragma is not at the top of the file" do
@@ -115,59 +97,11 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::FileFilter, :config do
     end
 
     context "when the file has no magic comment" do
-      it_behaves_like "runs on the file"
-    end
-  end
-
-  context "when Mode is unset (legacy default)" do
-    let(:config) { RuboCop::Config.new("Style/RbsInline/InvalidComment" => {}) }
-
-    context "when the file has `# rbs_inline: enabled`" do
       it "reports offenses" do
         expect_offense(<<~RUBY)
-          # rbs_inline: enabled
           # () -> void
           ^^^^^^^^^^^^ Invalid RBS annotation comment found.
         RUBY
-      end
-    end
-
-    context "when the file has `# rbs_inline: disabled`" do
-      it "reports offenses (no filter applied when Mode is unset)" do
-        expect_offense(<<~RUBY)
-          # rbs_inline: disabled
-          # () -> void
-          ^^^^^^^^^^^^ Invalid RBS annotation comment found.
-        RUBY
-      end
-    end
-
-    context "when the file has no magic comment" do
-      it_behaves_like "runs on the file"
-    end
-  end
-
-  context "when Mode is set to an invalid value" do
-    context "with a typo string" do
-      let(:config) { RuboCop::Config.new("Style/RbsInline" => { "Mode" => "opt-in" }) }
-
-      it "warns and disables filtering for the run" do
-        expect_offense(<<~RUBY)
-          # () -> void
-          ^^^^^^^^^^^^ Invalid RBS annotation comment found.
-        RUBY
-
-        expect(Kernel).to have_received(:warn).with(/Mode "opt-in" is not supported/)
-      end
-    end
-
-    context "with a YAML-native non-string type" do
-      let(:config) { RuboCop::Config.new("Style/RbsInline" => { "Mode" => 42 }) }
-
-      it "does not raise (falls back to no filter)" do
-        processed = parse_source("# () -> void\n", "example.rb")
-        commissioner = RuboCop::Cop::Commissioner.new([cop], [], raise_error: true)
-        expect { commissioner.investigate(processed) }.not_to raise_error
       end
     end
   end

--- a/spec/rubocop/cop/style/rbs_inline/mixin/mode_config_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/mixin/mode_config_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# These specs exercise the shared `ModeConfig` mixin using
+# `Style/RbsInline/InvalidComment` as a vehicle cop.
+RSpec.describe RuboCop::Cop::Style::RbsInline::ModeConfig, :config do
+  let(:cop_class) { RuboCop::Cop::Style::RbsInline::InvalidComment }
+
+  describe "#validate_config" do
+    subject { cop.validate_config }
+
+    context "when Mode is supported" do
+      let(:config) { RuboCop::Config.new("Style/RbsInline" => { "Mode" => "opt_out" }) }
+
+      it "does not raise" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when Mode is not supported" do
+      context "when Mode is unset" do
+        # An empty hash rather than no argument: `RuboCop::Config.new` defaults to
+        # the configuration `config/default.yml` is merged into.
+        let(:config) { RuboCop::Config.new({}) }
+
+        it "raises a validation error" do
+          expect { subject }
+            .to raise_error(RuboCop::ValidationError, %r{`Style/RbsInline: Mode: nil` is not supported})
+        end
+      end
+
+      context "when Mode is a typo string" do
+        let(:config) { RuboCop::Config.new("Style/RbsInline" => { "Mode" => "opt-in" }) }
+
+        it "raises a validation error" do
+          expect { subject }
+            .to raise_error(RuboCop::ValidationError, %r{`Style/RbsInline: Mode: "opt-in"` is not supported})
+        end
+      end
+
+      context "when Mode is a YAML-native non-string type" do
+        let(:config) { RuboCop::Config.new("Style/RbsInline" => { "Mode" => 42 }) }
+
+        it "raises a validation error" do
+          expect { subject }
+            .to raise_error(RuboCop::ValidationError, %r{`Style/RbsInline: Mode: 42` is not supported})
+        end
+      end
+    end
+
+    # Without the hook, the same error would be raised per file and reported as an
+    # inspection error, which leaves the run green.
+    context "when the cop is mobilized by RuboCop::Cop::Team" do
+      subject { RuboCop::Cop::Team.mobilize([cop_class], config) }
+
+      let(:config) { RuboCop::Config.new("Style/RbsInline" => { "Mode" => "opt-in" }) }
+
+      it "is called before any file is inspected" do
+        expect { subject }
+          .to raise_error(RuboCop::ValidationError, %r{`Style/RbsInline: Mode: "opt-in"` is not supported})
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/style/rbs_inline/parameters_separator_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/parameters_separator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::ParametersSeparator, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when using `#bad_method`" do
     it "registers an offense" do

--- a/spec/rubocop/cop/style/rbs_inline/redundant_type_annotation_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/redundant_type_annotation_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::RedundantTypeAnnotation, :config 
   context "when EnforcedStyle is method_type_signature" do
     let(:config) do
       RuboCop::Config.new(
+        "Style/RbsInline" => { "Mode" => "opt_out" },
         "Style/RbsInline/RedundantTypeAnnotation" => {
           "EnforcedStyle" => "method_type_signature",
           "SupportedStyles" => %w[method_type_signature doc_style doc_style_and_return_annotation]
@@ -269,6 +270,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::RedundantTypeAnnotation, :config 
   context "when EnforcedStyle is doc_style" do
     let(:config) do
       RuboCop::Config.new(
+        "Style/RbsInline" => { "Mode" => "opt_out" },
         "Style/RbsInline/RedundantTypeAnnotation" => {
           "EnforcedStyle" => "doc_style",
           "SupportedStyles" => %w[method_type_signature doc_style doc_style_and_return_annotation]
@@ -536,6 +538,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::RedundantTypeAnnotation, :config 
   context "when EnforcedStyle is doc_style_and_return_annotation" do
     let(:config) do
       RuboCop::Config.new(
+        "Style/RbsInline" => { "Mode" => "opt_out" },
         "Style/RbsInline/RedundantTypeAnnotation" => {
           "EnforcedStyle" => "doc_style_and_return_annotation",
           "SupportedStyles" => %w[method_type_signature doc_style doc_style_and_return_annotation]

--- a/spec/rubocop/cop/style/rbs_inline/require_rbs_inline_comment_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/require_rbs_inline_comment_spec.rb
@@ -1,22 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::RequireRbsInlineComment, :config do
-  before do
-    described_class.instance_variable_set(:@enforced_style_deprecation_warned, false)
-    allow(Kernel).to receive(:warn)
-  end
-
   # `Mode` is a department-level setting; everything else belongs to the cop.
-  def config_for(mode, cop_params)
+  def config_for(mode, cop_params = {})
     RuboCop::Config.new(
-      "Style/RbsInline" => mode ? { "Mode" => mode } : {},
+      "Style/RbsInline" => { "Mode" => mode },
       "Style/RbsInline/RequireRbsInlineComment" => cop_params
     )
   end
 
-  shared_examples "opt_in behavior" do |mode, cop_params = {}|
+  context "when Mode is opt_in" do
     context "when AllowMissingComment is false (default)" do
-      let(:config) { config_for(mode, cop_params) }
+      let(:config) { config_for("opt_in") }
 
       context "when the file has `# rbs_inline: enabled`" do
         it "does not register an offense" do
@@ -154,7 +149,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::RequireRbsInlineComment, :config 
     end
 
     context "when AllowMissingComment is true" do
-      let(:config) { config_for(mode, cop_params.merge("AllowMissingComment" => true)) }
+      let(:config) { config_for("opt_in", "AllowMissingComment" => true) }
 
       context "when the file has `# rbs_inline: enabled`" do
         it "does not register an offense" do
@@ -187,8 +182,8 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::RequireRbsInlineComment, :config 
     end
   end
 
-  shared_examples "opt_out behavior" do |mode, cop_params = {}|
-    let(:config) { config_for(mode, cop_params) }
+  context "when Mode is opt_out" do
+    let(:config) { config_for("opt_out") }
 
     context "when the file has `# rbs_inline: enabled`" do
       it "registers an offense and removes the magic comment" do
@@ -224,40 +219,5 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::RequireRbsInlineComment, :config 
         RUBY
       end
     end
-  end
-
-  context "when Mode is opt_in" do
-    it_behaves_like "opt_in behavior", "opt_in"
-  end
-
-  context "when Mode is opt_out" do
-    it_behaves_like "opt_out behavior", "opt_out"
-  end
-
-  context "when Mode is not set (legacy default)" do
-    it_behaves_like "opt_in behavior", nil
-  end
-
-  context "when only legacy EnforcedStyle is set" do
-    context "with EnforcedStyle: always" do
-      it_behaves_like "opt_in behavior", nil, { "EnforcedStyle" => "always" }
-    end
-
-    context "with EnforcedStyle: never" do
-      it_behaves_like "opt_out behavior", nil, { "EnforcedStyle" => "never" }
-    end
-
-    describe "deprecation warning" do
-      let(:config) { config_for(nil, { "EnforcedStyle" => "always" }) }
-
-      it "emits a deprecation warning for EnforcedStyle" do
-        expect_no_offenses("# rbs_inline: enabled\nclass Foo\nend\n")
-        expect(Kernel).to have_received(:warn).with(/EnforcedStyle is deprecated/)
-      end
-    end
-  end
-
-  context "when Mode overrides EnforcedStyle" do
-    it_behaves_like "opt_out behavior", "opt_out", { "EnforcedStyle" => "always" }
   end
 end

--- a/spec/rubocop/cop/style/rbs_inline/struct_class_comment_alignment_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/struct_class_comment_alignment_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::StructClassCommentAlignment, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "with an annotation that is too close" do
     it "registers an offense and corrects it" do

--- a/spec/rubocop/cop/style/rbs_inline/struct_new_with_block_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/struct_new_with_block_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::StructNewWithBlock, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when Struct.new is called with a do...end block" do
     it "registers an offense" do

--- a/spec/rubocop/cop/style/rbs_inline/unmatched_annotations_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/unmatched_annotations_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::UnmatchedAnnotations, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when an annotation comment found above the instance method definition" do
     context "when the comment annotates to unknown argument" do

--- a/spec/rubocop/cop/style/rbs_inline/untyped_instance_variable_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/untyped_instance_variable_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::UntypedInstanceVariable, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when instance variable has no type annotation" do
     context "with an ivar read (may be defined in parent class)" do

--- a/spec/rubocop/cop/style/rbs_inline/variable_comment_spacing_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/variable_comment_spacing_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Style::RbsInline::VariableCommentSpacing, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { rbs_inline_config }
 
   context "when @rbs @ivar comment is directly followed by code" do
     it "registers an offense" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,25 @@
 require "rubocop-rbs_inline"
 require "rubocop/rspec/support"
 
+# `Mode` has no default outside `config/default.yml`, so every spec declares one.
+# `opt_out` is the mode that inspects the plain sources specs are written with.
+RSpec.shared_context "with Mode: opt_out" do
+  let(:other_cops) { { "Style/RbsInline" => { "Mode" => "opt_out" } } }
+end
+
+# Same declaration, for the specs written against the default configuration.
+module RbsInlineConfigHelper
+  def rbs_inline_config
+    defaults = RuboCop::ConfigLoader.default_configuration
+    department = defaults["Style/RbsInline"].merge("Mode" => "opt_out")
+    RuboCop::Config.new(defaults.merge("Style/RbsInline" => department))
+  end
+end
+
 RSpec.configure do |config|
+  config.include_context "with Mode: opt_out", :config
+  config.include RbsInlineConfigHelper
+
   config.disable_monkey_patching!
   config.raise_errors_for_deprecations!
   config.raise_on_warning = true


### PR DESCRIPTION
`Mode` shipped in 1.8.0 with a legacy escape hatch on every path: unset meant "check every file", and an unsupported value warned once and then also meant "check every file". `RequireRbsInlineComment` carried a second route to the same decision through the deprecated `EnforcedStyle`.

For the major version, make `Mode` a regular setting. It defaults to `opt_in` in config/default.yml -- the mode rbs-inline itself defaults to -- and a value that resolves to anything else now fails the run with a `ValidationError`. RuboCop calls `validate_config` while it mobilizes its cops, so the error surfaces as a config error rather than as an inspection error on every file, which exits 0 and reports no offenses. Projects that run rbs-inline in opt-out mode now have to declare `Style/RbsInline: Mode: opt_out`.

Resolution moves out of `FileFilter` into a `ModeConfig` mixin, so the one cop that cannot be filtered by `FileFilter` (`RequireRbsInlineComment` has to run on the very files the filter skips) reads the mode the same way instead of duplicating the lookup.

`EnforcedStyle` is removed: `always` is `Mode: opt_in`, `never` is `Mode: opt_out`. 1.8.0 already warned on every run that configured it, so a leftover one is left to RuboCop's own unsupported parameter warning.

Specs have no default to fall back on either: `spec_helper` declares `Mode: opt_out` for `:config` specs, which is the mode that inspects the plain sources the specs are written with.

### Added test cases

`spec/rubocop/cop/style/rbs_inline/mixin/mode_config_spec.rb` (`#validate_config`)

- when Mode is supported — does not raise
- when Mode is not supported / when Mode is unset — raises a `ValidationError` naming `Mode: nil`
- when Mode is not supported / when Mode is a typo string — raises a `ValidationError` for `opt-in`
- when Mode is not supported / when Mode is a YAML-native non-string type — raises a `ValidationError` for `42` rather than a `NoMethodError`
- when the cop is mobilized by RuboCop::Cop::Team — the hook is called, so the error surfaces before any file is inspected
