### PR TITLE
chore: catch up with the shared Ruby skeleton and hooks

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -18,10 +18,50 @@ fi
 
 echo "Running pre-commit checks..." >&2
 
-# Generate RBS and run all checks
-if ! bundle exec rbs-inline --opt-out --output=sig/ lib/ >&2; then
+# Regenerate RBS from scratch so that files orphaned by deleted lib/ sources are dropped too
+if ! bundle exec rake rbs:regenerate >&2; then
     echo "Error: RBS generation failed" >&2
     exit 2
+fi
+
+# True when $command stages the whole of sig/ itself, which the check below cannot see because
+# this hook runs first. Staging only part of sig/ does not count - the rest still drops out.
+stages_sig() {
+    local segment tokens token stages_everything pathspec_given
+
+    while IFS= read -r segment; do
+        segment=${segment//[\"\']/}
+        read -ra tokens <<<"${segment#*add}"
+        stages_everything=0
+        pathspec_given=0
+
+        for token in "${tokens[@]}"; do
+            case "$token" in
+                --) ;;
+                -*A*|--all) stages_everything=1 ;;
+                -*) ;;
+                .|./|sig|sig/|./sig|./sig/) return 0 ;;
+                *) pathspec_given=1 ;;
+            esac
+        done
+
+        # -A alone stages every path; given a pathspec it stages that path only
+        [ "$stages_everything" = 1 ] && [ "$pathspec_given" = 0 ] && return 0
+    done < <(grep -oE '(^|[;&|(])[[:space:]]*git[[:space:]]+add[^;&|(]*' <<<"$command")
+
+    return 1
+}
+
+# Stop rather than let the RBS just regenerated above drop out of the commit unnoticed
+if [[ "$command" =~ git[[:space:]]+commit([[:space:]]|$) ]] && ! stages_sig; then
+    unstaged_sig=$(git status --porcelain --untracked-files=all -- sig/ | awk 'substr($0, 2, 1) != " "')
+
+    if [ -n "$unstaged_sig" ]; then
+        echo "Error: sig/ has changes that are not staged:" >&2
+        echo "$unstaged_sig" >&2
+        echo "Run 'git add sig/' and commit again." >&2
+        exit 2
+    fi
 fi
 
 if ! bundle exec rake >&2; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "permissions": {
-    "allow": ["RemoteTrigger"]
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - 'lib/rubocop/rbs_inline/version.rb'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,11 +44,11 @@ Naming/FileName:
 RSpec/ExampleLength:
   Enabled: false
 
-RSpec/MultipleMemoizedHelpers:
-  Max: 10
-
 RSpec/MultipleExpectations:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
 
 RSpec/NamedSubject:
   Enabled: false
@@ -62,16 +62,6 @@ RSpec/SpecFilePathFormat:
   Exclude:
     - "spec/rubocop/cop/style/rbs_inline/mixin/**/*_spec.rb"
 
-# RbsInline
-Style/RbsInline:
-  Mode: opt_out
-
-Style/RbsInline/MissingTypeAnnotation:
-  EnforcedStyle: doc_style_and_return_annotation
-
-Style/RbsInline/RedundantTypeAnnotation:
-  EnforcedStyle: doc_style_and_return_annotation
-
 # Style
 Style/AccessorGrouping:
   Enabled: false
@@ -84,6 +74,15 @@ Style/Documentation:
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: always
+
+Style/RbsInline:
+  Mode: opt_out
+
+Style/RbsInline/MissingTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
+
+Style/RbsInline/RedundantTypeAnnotation:
+  EnforcedStyle: doc_style_and_return_annotation
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Rakefile
+++ b/Rakefile
@@ -35,14 +35,23 @@ task :new_cop, [:cop] do |_task, args|
 end
 
 namespace :rbs do
-  desc "Install RBS signatures"
+  # sig/gems holds hand-written types for external gems, so it is never regenerated
+  kept = ->(path) { path == "sig/gems" || path.start_with?("sig/gems/") }
+
+  desc "Install RBS collection"
   task :install do
     sh "bundle", "exec", "rbs", "collection", "install", "--frozen"
   end
 
-  desc "Generate RBS files"
-  task :generate do
+  desc "Regenerate all RBS files under sig/ from scratch (run manually after editing lib/)"
+  task :regenerate do
+    Dir.glob("sig/**/*.rbs").reject(&kept).each { rm _1 }
+
     sh "rbs-inline", "--opt-out", "--output=sig", "lib"
+
+    # Drop the directories the deletion above left empty, deepest first
+    dirs = Dir.glob("sig/**/*").select { File.directory?(_1) }
+    dirs.reject(&kept).sort.reverse_each { rmdir _1 if Dir.empty?(_1) }
   end
 
   desc "Validate RBS files"


### PR DESCRIPTION
## Summary

Same sweep as tk0miya/not_nilable#43, applied to this repository. Four commits, one topic each.

## `chore: replace rbs:generate with rbs:regenerate`

`rbs:generate` overwrote signatures in place, so a signature whose `lib/` source was deleted stayed behind in `sig/` forever. `rbs:regenerate` deletes the generated tree first and regenerates from scratch, keeping the hand-written `sig/gems/` stubs — the same directory CLAUDE.md already calls out as off-limits when refreshing signatures.

The rbs-inline invocation keeps this Rakefile's existing argument-array form rather than the skeleton's single command string.

## `hooks: sync pre-commit-check.sh with setup-ruby-hooks`

It regenerates RBS via `rake rbs:regenerate` and refuses to commit while `sig/` has unstaged changes, so signatures it just regenerated cannot silently drop out of the commit.

`rbs-inline.sh` was already identical to the template. `protect-sig-files.sh` is absent here, and adding it would be a new adoption rather than catching up, so it stays out of this PR.

## `chore: drop the ineffective RemoteTrigger permission rule`

`RemoteTrigger` was never a real permission rule name. Upstream tried the actual MCP tool identifiers, verified those had no effect either, and removed the block entirely.

## `chore: fix rubocop.yml ordering and declare release.yml permissions`

`.rubocop.yml` claims ASCII ordering but `RSpec/MultipleMemoizedHelpers` preceded `RSpec/MultipleExpectations`, and the `Style/RbsInline` cops sat in their own section ahead of `Style/`. No cop configuration changes. `release.yml` was the one workflow without a top-level `permissions` block.

## Verification

Run locally against this branch:

- `bundle exec rake rbs:regenerate` — regenerates 36 signatures, **leaves `sig/gems/` untouched**, and leaves `sig/` unchanged overall, so the task is idempotent here.
- `bundle exec rake ci` — passes: rubocop, spec, steep ("No type error detected" over 73 files), `rbs:validate`.
- `actionlint` — passes.
- `pre-commit-check.sh`, `rbs-inline.sh` and `self-review.sh` are byte-identical to their skill templates. Every pinned action SHA was checked against the `tags` API.

No test cases were added: the changes are build, lint and hook configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)