### PR TITLE
Improve messaging for Data.define/Struct.new block violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **Style/RbsInline**: `Mode` now defaults to `opt_in`, and any value other than `opt_in` / `opt_out` fails the run.
 - **Style/RbsInline/RequireRbsInlineComment**: Removed the deprecated `EnforcedStyle`. Use `Style/RbsInline: Mode` instead: `always` → `opt_in`, `never` → `opt_out`.
 
+### Enhancements
+
+- **Style/RbsInline/DataDefineWithBlock**, **Style/RbsInline/StructNewWithBlock**: Clarified the offense message: it now says to keep the `Data.define` / `Struct.new` call and move the block's methods into a class that reopens it, and names that class when the definition is assigned to a constant.
+
 ## 1.8.0 (2026-07-26)
 
 ### Enhancements

--- a/lib/rubocop/cop/style/rbs_inline/data_define_with_block.rb
+++ b/lib/rubocop/cop/style/rbs_inline/data_define_with_block.rb
@@ -30,10 +30,11 @@ module RuboCop
         class DataDefineWithBlock < Base
           prepend FileFilter
           include DataClassMatcher
+          include ASTUtils
 
           MSG = "Do not use `Data.define` with a block. RBS::Inline does not parse block contents, " \
-                "so methods defined in the block will not be recognized. " \
-                "Use a separate class definition instead."
+                "so methods defined in the block will not be recognized. Keep the `Data.define` call " \
+                "and move the methods into %<destination>s."
 
           # @rbs node: RuboCop::AST::SendNode
           def on_send(node) #: void
@@ -42,7 +43,18 @@ module RuboCop
             block_node = node.parent
             return unless block_node&.block_type?
 
-            add_offense(node)
+            add_offense(node, message: format(MSG, destination: destination(block_node)))
+          end
+
+          private
+
+          # The constant the definition is assigned to is the class to reopen.
+          # @rbs node: RuboCop::AST::Node
+          def destination(node) #: String
+            class_name = assigned_constant_name(node)
+            return "a `class` that reopens it" unless class_name
+
+            "`class #{class_name} ... end` written after it"
           end
         end
       end

--- a/lib/rubocop/cop/style/rbs_inline/mixin/ast_utils.rb
+++ b/lib/rubocop/cop/style/rbs_inline/mixin/ast_utils.rb
@@ -39,6 +39,19 @@ module RuboCop
             node.source || raise
           end
 
+          # Returns the name of the constant `node` is assigned to, or `nil` when the name
+          # is not statically determinable (e.g. `self::Foo = ...`).
+          # @rbs node: RuboCop::AST::Node
+          def assigned_constant_name(node) #: String?
+            parent = node.parent
+            return nil unless parent.is_a?(RuboCop::AST::CasgnNode)
+            return nil unless parent.each_path.all? { _1.const_type? || _1.cbase_type? }
+
+            # `const_name` drops the leading `::`, which would name a different constant
+            # when the assignment appears inside a namespace.
+            parent.absolute? ? "::#{parent.const_name}" : parent.const_name
+          end
+
           #: (RuboCop::AST::SymbolNode) -> Symbol
           #: (RuboCop::AST::StrNode) -> Symbol
           #: (RuboCop::AST::Node) -> Symbol?

--- a/lib/rubocop/cop/style/rbs_inline/struct_new_with_block.rb
+++ b/lib/rubocop/cop/style/rbs_inline/struct_new_with_block.rb
@@ -27,10 +27,11 @@ module RuboCop
         class StructNewWithBlock < Base
           prepend FileFilter
           include StructClassMatcher
+          include ASTUtils
 
           MSG = "Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, " \
-                "so methods defined in the block will not be recognized. " \
-                "Use a separate class definition instead."
+                "so methods defined in the block will not be recognized. Keep the `Struct.new` call " \
+                "and move the methods into %<destination>s."
 
           # @rbs node: RuboCop::AST::SendNode
           def on_send(node) #: void
@@ -39,7 +40,18 @@ module RuboCop
             block_node = node.parent
             return unless block_node&.block_type?
 
-            add_offense(node)
+            add_offense(node, message: format(MSG, destination: destination(block_node)))
+          end
+
+          private
+
+          # The constant the definition is assigned to is the class to reopen.
+          # @rbs node: RuboCop::AST::Node
+          def destination(node) #: String
+            class_name = assigned_constant_name(node)
+            return "a `class` that reopens it" unless class_name
+
+            "`class #{class_name} ... end` written after it"
           end
         end
       end

--- a/sig/rubocop/cop/style/rbs_inline/data_define_with_block.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/data_define_with_block.rbs
@@ -31,10 +31,18 @@ module RuboCop
 
           include DataClassMatcher
 
+          include ASTUtils
+
           MSG: ::String
 
           # @rbs node: RuboCop::AST::SendNode
           def on_send: (RuboCop::AST::SendNode node) -> void
+
+          private
+
+          # The constant the definition is assigned to is the class to reopen.
+          # @rbs node: RuboCop::AST::Node
+          def destination: (RuboCop::AST::Node node) -> String
         end
       end
     end

--- a/sig/rubocop/cop/style/rbs_inline/mixin/ast_utils.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/mixin/ast_utils.rbs
@@ -23,6 +23,11 @@ module RuboCop
           # @rbs node: RuboCop::AST::Node
           def source!: (RuboCop::AST::Node node) -> String
 
+          # Returns the name of the constant `node` is assigned to, or `nil` when the name
+          # is not statically determinable (e.g. `self::Foo = ...`).
+          # @rbs node: RuboCop::AST::Node
+          def assigned_constant_name: (RuboCop::AST::Node node) -> String?
+
           # : (RuboCop::AST::SymbolNode) -> Symbol
           # : (RuboCop::AST::StrNode) -> Symbol
           # : (RuboCop::AST::Node) -> Symbol?

--- a/sig/rubocop/cop/style/rbs_inline/struct_new_with_block.rbs
+++ b/sig/rubocop/cop/style/rbs_inline/struct_new_with_block.rbs
@@ -28,10 +28,18 @@ module RuboCop
 
           include StructClassMatcher
 
+          include ASTUtils
+
           MSG: ::String
 
           # @rbs node: RuboCop::AST::SendNode
           def on_send: (RuboCop::AST::SendNode node) -> void
+
+          private
+
+          # The constant the definition is assigned to is the class to reopen.
+          # @rbs node: RuboCop::AST::Node
+          def destination: (RuboCop::AST::Node node) -> String
         end
       end
     end

--- a/spec/rubocop/cop/style/rbs_inline/data_define_with_block_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/data_define_with_block_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::DataDefineWithBlock, :config do
     it "registers an offense" do
       expect_offense(<<~RUBY)
         User = Data.define(:name, :role) do
-               ^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Data.define` call and move the methods into `class User ... end` written after it.
           def admin?
             role == :admin
           end
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::DataDefineWithBlock, :config do
     it "registers an offense" do
       expect_offense(<<~RUBY)
         User = Data.define(:name, :role) { }
-               ^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Data.define` call and move the methods into `class User ... end` written after it.
       RUBY
     end
   end
@@ -29,11 +29,47 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::DataDefineWithBlock, :config do
     it "registers an offense" do
       expect_offense(<<~RUBY)
         Empty = Data.define do
-                ^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+                ^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Data.define` call and move the methods into `class Empty ... end` written after it.
           def foo
             42
           end
         end
+      RUBY
+    end
+  end
+
+  context "when Data.define with a block is assigned to a namespaced constant" do
+    it "names the namespaced class to reopen" do
+      expect_offense(<<~RUBY)
+        Foo::User = Data.define(:name) { }
+                    ^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Data.define` call and move the methods into `class Foo::User ... end` written after it.
+      RUBY
+    end
+  end
+
+  context "when Data.define with a block is assigned under a dynamic namespace" do
+    it "registers an offense without a class name" do
+      expect_offense(<<~RUBY)
+        self::Foo::User = Data.define(:name) { }
+                          ^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Data.define` call and move the methods into a `class` that reopens it.
+      RUBY
+    end
+  end
+
+  context "when Data.define with a block is assigned to a constant at the root namespace" do
+    it "keeps the leading `::` in the class name" do
+      expect_offense(<<~RUBY)
+        ::User = Data.define(:name) { }
+                 ^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Data.define` call and move the methods into `class ::User ... end` written after it.
+      RUBY
+    end
+  end
+
+  context "when Data.define with a block is not assigned to a constant" do
+    it "registers an offense without a class name" do
+      expect_offense(<<~RUBY)
+        user = Data.define(:name) { }
+               ^^^^^^^^^^^^^^^^^^ Style/RbsInline/DataDefineWithBlock: Do not use `Data.define` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Data.define` call and move the methods into a `class` that reopens it.
       RUBY
     end
   end

--- a/spec/rubocop/cop/style/rbs_inline/struct_new_with_block_spec.rb
+++ b/spec/rubocop/cop/style/rbs_inline/struct_new_with_block_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::StructNewWithBlock, :config do
     it "registers an offense" do
       expect_offense(<<~RUBY)
         User = Struct.new(:name, :role) do
-               ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+               ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Struct.new` call and move the methods into `class User ... end` written after it.
           def admin?
             role == :admin
           end
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::StructNewWithBlock, :config do
     it "registers an offense" do
       expect_offense(<<~RUBY)
         User = Struct.new(:name, :role) { }
-               ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+               ^^^^^^^^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Struct.new` call and move the methods into `class User ... end` written after it.
       RUBY
     end
   end
@@ -29,11 +29,47 @@ RSpec.describe RuboCop::Cop::Style::RbsInline::StructNewWithBlock, :config do
     it "registers an offense" do
       expect_offense(<<~RUBY)
         Empty = Struct.new do
-                ^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Use a separate class definition instead.
+                ^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Struct.new` call and move the methods into `class Empty ... end` written after it.
           def foo
             42
           end
         end
+      RUBY
+    end
+  end
+
+  context "when Struct.new with a block is assigned to a namespaced constant" do
+    it "names the namespaced class to reopen" do
+      expect_offense(<<~RUBY)
+        Foo::User = Struct.new(:name) { }
+                    ^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Struct.new` call and move the methods into `class Foo::User ... end` written after it.
+      RUBY
+    end
+  end
+
+  context "when Struct.new with a block is assigned under a dynamic namespace" do
+    it "registers an offense without a class name" do
+      expect_offense(<<~RUBY)
+        self::Foo::User = Struct.new(:name) { }
+                          ^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Struct.new` call and move the methods into a `class` that reopens it.
+      RUBY
+    end
+  end
+
+  context "when Struct.new with a block is assigned to a constant at the root namespace" do
+    it "keeps the leading `::` in the class name" do
+      expect_offense(<<~RUBY)
+        ::User = Struct.new(:name) { }
+                 ^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Struct.new` call and move the methods into `class ::User ... end` written after it.
+      RUBY
+    end
+  end
+
+  context "when Struct.new with a block is not assigned to a constant" do
+    it "registers an offense without a class name" do
+      expect_offense(<<~RUBY)
+        user = Struct.new(:name) { }
+               ^^^^^^^^^^^^^^^^^ Style/RbsInline/StructNewWithBlock: Do not use `Struct.new` with a block. RBS::Inline does not parse block contents, so methods defined in the block will not be recognized. Keep the `Struct.new` call and move the methods into a `class` that reopens it.
       RUBY
     end
   end


### PR DESCRIPTION
## Summary

Clarified the offense message of `DataDefineWithBlock` and `StructNewWithBlock`. The old wording ("Use a separate class definition instead.") reads as "stop using `Data.define` / `Struct.new` and write a class", and the offense was often "fixed" by rewriting the definition as a plain class with a hand-written `initialize` and `attr_reader` / `attr_accessor`.

Detection is unchanged: the same calls are flagged at the same range as before, and the cop documentation and README are untouched because the behavior users get is the same.

## Key Changes

- **Offense message**: it now says to keep the `Data.define` / `Struct.new` call and move the block's methods into a class that reopens it. When the definition is assigned to a constant, the message names that class:

  ```
  Do not use `Data.define` with a block. RBS::Inline does not parse block contents,
  so methods defined in the block will not be recognized. Keep the `Data.define` call
  and move the methods into `class User ... end` written after it.
  ```

  A namespaced constant becomes `class Foo::User ... end`, and `::User = ...` keeps its leading `::`. When the name is not statically determinable (`self::Foo::User = ...`) or the definition is not assigned to a constant, it falls back to the generic `a `class` that reopens it`.

- **`ASTUtils#assigned_constant_name`**: resolves the constant a node is assigned to, returning `nil` unless every path component is a `const` / `cbase` node. Each cop builds its own message from it in a private `destination` method.

## Expanded test coverage

Both `data_define_with_block_spec.rb` and `struct_new_with_block_spec.rb` gain the same four contexts:

- `... is assigned to a namespaced constant` — the message names `class Foo::User ... end`
- `... is assigned under a dynamic namespace` — `self::Foo::User = ...` falls back to the generic wording
- `... is assigned to a constant at the root namespace` — `::User = ...` keeps the leading `::`
- `... is not assigned to a constant` — a local variable falls back to the generic wording

The existing contexts only had their expected message updated.

https://claude.ai/code/session_01A2FrLTz58HVF5UBTSuWp9t