### PR TITLE
Release version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.0.0 (2026-08-05)
 
 ### Breaking Changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-rbs_inline (1.8.0)
+    rubocop-rbs_inline (2.0.0)
       lint_roller (~> 1.1)
       rbs-inline
       rubocop (>= 1.72.1, < 2.0)

--- a/lib/rubocop/rbs_inline/version.rb
+++ b/lib/rubocop/rbs_inline/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module RbsInline
-    VERSION = "1.8.0"
+    VERSION = "2.0.0"
   end
 end


### PR DESCRIPTION
## Summary

This release marks version 2.0.0 of rubocop-rbs_inline with breaking changes.

## Changes

- Bumped version from 1.8.0 to 2.0.0
- Updated CHANGELOG.md to document the 2.0.0 release (2026-08-05)

## Notes

This is a major version bump indicating breaking changes have been introduced. See CHANGELOG.md for details on what changed in this release.

https://claude.ai/code/session_01FwCcF5szrVQuZsd7Fd9Yhn